### PR TITLE
Bump golang version for release.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
Change Golang version from 1.15 to 1.18 on release.yaml to match go.mod

Signed-off-by: Yrineu Rodrigues <yrineu@pontovinte.com>