### PR TITLE
Fix #66: Remove warning 

### DIFF
--- a/internal/provider/resource_outbound_cross_connect.go
+++ b/internal/provider/resource_outbound_cross_connect.go
@@ -112,16 +112,11 @@ func resourceOutboundCrossConnectCreate(ctx context.Context, d *schema.ResourceD
 	c.Ctx = ctx
 	var diags diag.Diagnostics
 	crossConn := extractCrossConnect(d)
-	resp, err := c.CreateOutboundCrossConnect(crossConn)
+	_, err := c.CreateOutboundCrossConnect(crossConn)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	d.SetId(uuid.New().String())
-	diags = append(diags, diag.Diagnostic{
-		Severity: diag.Warning,
-		Summary:  "Outbound Cross Connect Create",
-		Detail:   resp.Message,
-	})
 	return diags
 }
 


### PR DESCRIPTION
Remove warning after `outbound_cross_connect` create.