### PR TITLE
Update ghaction-import-gpg and goreleaser-action to the latest versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,14 +32,14 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v5.0.0
+        uses: crazy-max/ghaction-import-gpg@v5.1.0
         with:
           # These secrets will need to be configured for the repository:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.9.1
+        uses: goreleaser/goreleaser-action@v3.1.0
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
Bumping version for both `ghaction-import-gpg` and `goreleaser-action` to the latest.

See example [here](https://github.com/goreleaser/goreleaser-action#signing).