### PR TITLE
Rename Aws to AWS and remove workaround BGP delete in use case

### DIFF
--- a/examples/use-cases/cloud_router_aws/README.md
+++ b/examples/use-cases/cloud_router_aws/README.md
@@ -107,14 +107,8 @@ If you want to use iperf3, open a ssh session using the user ``ubuntu`` and the 
 4. Destroy all remote objects managed by the Terraform configuration.
 
 ```sh
-terraform state rm cloud_router_bgp_session.crbs_1
-terraform state rm cloud_router_bgp_session.crbs_2
-terraform state rm cloud_router_bgp_prefixes.crbp_1
-terraform state rm cloud_router_bgp_prefixes.crbp_2
 terraform destroy -var-file="secret.tfvars"
 ```
-
-**Note:** We are removing the Cloud Router BGP session and prefix resources from the terraform state as those will be deleted together with current Cloud Router Connection. See https://github.com/PacketFabric/terraform-provider-packetfabric/issues/20.
 
 ## Troubleshooting
 

--- a/internal/provider/resource_aws_request_dedicated_conn.go
+++ b/internal/provider/resource_aws_request_dedicated_conn.go
@@ -137,7 +137,7 @@ func resourceAwsServicesDelete(ctx context.Context, d *schema.ResourceData, m in
 	if !ok {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Warning,
-			Summary:  "Aws Services Delete",
+			Summary:  "AWS Services Delete",
 			Detail:   cloudCidNotFoundDetailsMsg,
 		})
 		return diags

--- a/internal/provider/resource_router_connection.go
+++ b/internal/provider/resource_router_connection.go
@@ -199,7 +199,7 @@ func resourceRouterConnectionAwsDelete(ctx context.Context, d *schema.ResourceDa
 	}
 	diags = append(diags, diag.Diagnostic{
 		Severity: diag.Warning,
-		Summary:  "Aws Router connection result",
+		Summary:  "AWS Router connection result",
 		Detail:   resp.Message,
 	})
 	d.SetId("")


### PR DESCRIPTION
- Rename Aws to AWS
- Remove workaround BGP delete in Cloud Router AWS use case example