### PR TITLE
Updated resource name that was incorrect in documentation.

### DIFF
--- a/docs/resources/packetfabric_backbone_virtual_circuit.md
+++ b/docs/resources/packetfabric_backbone_virtual_circuit.md
@@ -47,7 +47,7 @@ output "packetfabric_port_2" {
 }
 
 # Create backbone Virtual Circuit
-resource "packetfabric_create_backbone_virtual_circuit" "vc1" {
+resource "packetfabric_backbone_virtual_circuit" "vc1" {
   provider    = packetfabric
   description = var.description
   epl         = false

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -116,7 +116,7 @@ output "packetfabric_port_1a" {
 # #######################################
 
 # # Create backbone Virtual Circuit
-# resource "packetfabric_create_backbone_virtual_circuit" "vc1" {
+# resource "packetfabric_backbone_virtual_circuit" "vc1" {
 #   provider    = packetfabric
 #   description = "${var.tag_name}-${random_pet.name.id}"
 #   epl         = false

--- a/examples/resources/packetfabric_backbone_virtual_circuit/resource.tf
+++ b/examples/resources/packetfabric_backbone_virtual_circuit/resource.tf
@@ -24,7 +24,7 @@ resource "packetfabric_port" "port_2" {
   zone              = var.pf_port_avzone2
 }
 
-resource "packetfabric_create_backbone_virtual_circuit" "vc1" {
+resource "packetfabric_backbone_virtual_circuit" "vc1" {
   provider    = packetfabric
   description = var.description
   epl         = false

--- a/examples/use-cases/backbone_virtual_circuit/README.md
+++ b/examples/use-cases/backbone_virtual_circuit/README.md
@@ -21,7 +21,7 @@ the outbound Cross connect for those 2 ports.
 - data source **"packetfabric_billing"**: Get the billing details for those 2 ports
 - data source **"packetfabric_locations"**: Get PacketFabric available locations
 - resource **"packetfabric_outbound_cross_connect"**: Customer Inbound/PacketFabric Outbound Cross Connect (You provide PacketFabric with an LOA/CFA authorizing us to make the connection)
-- resource **"packetfabric_create_backbone_virtual_circuit"**: Create a Backbone Virtual Circuit between the 2 ports
+- resource **"packetfabric_backbone_virtual_circuit"**: Create a Backbone Virtual Circuit between the 2 ports
 
 
 ## Before You Begin


### PR DESCRIPTION
packetfabric_create_backbone_virtual_circuit -> packetfabric_backbone_virtual_circuit in:

* docs/resources/packetfabric_backbone_virtual_circuit.md
* examples/main.tf
* examples/resources/packetfabric_backbone_virtual_circuit/resource.tf
* examples/use-cases/backbone_virtual_circuit/README.md