### PR TITLE
Mark packetfabric_cloud_router scope as deprecated

### DIFF
--- a/internal/provider/resource_cloud_router.go
+++ b/internal/provider/resource_cloud_router.go
@@ -31,7 +31,8 @@ func resourceCloudRouter() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
-				Description:  "Whether the cloud router is private or public. Deprecated.",
+				Description:  "Whether the cloud router is private or public.",
+				Deprecated:   "Deprecated. Remove this attribute's configuration as it is no longer used, and the attribute will be removed in the next major version of the provider.",
 			},
 			"asn": {
 				Type:        schema.TypeInt,


### PR DESCRIPTION
This way, terraform will produce a warning for the user during runtime that a deprecated value is used.