### PR TITLE
Fix/169: Change required params to optional

### DIFF
--- a/internal/provider/resource_backbone.go
+++ b/internal/provider/resource_backbone.go
@@ -220,8 +220,12 @@ func extractBandwidth(bw map[string]interface{}) packetfabric.Bandwidth {
 	if longhaulType != nil {
 		bandwidth.LonghaulType = longhaulType.(string)
 	}
-	bandwidth.SubscriptionTerm = bw["subscription_term"].(int)
-	bandwidth.Speed = bw["speed"].(string)
+	if subsTerm := bw["subscription_term"]; subsTerm != nil {
+		bandwidth.SubscriptionTerm = subsTerm.(int)
+	}
+	if speed := bw["speed"]; speed != nil {
+		bandwidth.Speed = speed.(string)
+	}
 	return bandwidth
 }
 

--- a/internal/provider/resource_ix_vc.go
+++ b/internal/provider/resource_ix_vc.go
@@ -69,13 +69,13 @@ func resourceIxVC() *schema.Resource {
 						},
 						"speed": {
 							Type:         schema.TypeString,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: validation.StringInSlice(ixVcSpeedOptions(), true),
 							Description:  "The desired speed of the new connection. Only applicable if `longhaul_type` is \"dedicated\" or \"hourly\".\n\n\tEnum: [\"50Mbps\" \"100Mbps\" \"200Mbps\" \"300Mbps\" \"400Mbps\" \"500Mbps\" \"1Gbps\" \"2Gbps\" \"5Gbps\" \"10Gbps\" \"20Gbps\" \"30Gbps\" \"40Gbps\" \"50Gbps\" \"60Gbps\" \"80Gbps\" \"100Gbps\"]",
 						},
 						"subscription_term": {
 							Type:         schema.TypeInt,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: validation.IntInSlice([]int{1, 12, 24, 36}),
 							Description:  "The billing term, in months, for this connection. Only applicable if `longhaul_type` is \"dedicated.\"\n\n\tEnum: [\"1\", \"12\", \"24\", \"36\"]",
 						},


### PR DESCRIPTION
Change `speed` and `subscription_term` required params to optional.

Signed-off-by: Yrineu Rodrigues <yrineu@pontovinte.com>