### PR TITLE
Add warning in ACC section's README, update issue templates and CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -87,6 +87,6 @@ To obtain the debug output, see the [Terraform documentation on debugging](https
 Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
 
 Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor documentation? For example:
---->
 
 * #0000
+--->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -43,6 +43,6 @@ assignees: ''
 Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
 
 Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
---->
 
 * #0000
+--->

--- a/.github/ISSUE_TEMPLATE/terraform-packetfabric-provider-questions.md
+++ b/.github/ISSUE_TEMPLATE/terraform-packetfabric-provider-questions.md
@@ -33,6 +33,6 @@ assignees: ''
 Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
 
 Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
---->
 
 * #0000
+--->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@
         * using real data `<resource_name>_test.go` under `internal/provider` (see [ACC](https://github.com/PacketFabric/terraform-provider-packetfabric#acceptance-tests))
     * Add/Update examples under `examples/resources` and/or `examples/data-sources` (used for the documentation)
     * Add/Update the templates used to generate the docs  under `templates`
-    * Generate the docs using tfplugindocs (or update the necessary `*md` under `docs/`)
+    * Generate the docs using tfplugindocs (or update the necessary `*.md` under `docs/`)
     * Find more details on the [Readme](https://github.com/PacketFabric/terraform-provider-packetfabric).
 
 * Create your own branch with your updates including code changes, test, examples and documentation. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,10 @@
     * Add/Update Terraform Go Code located under the internal folder 
     * Add/Update Tests 
         * using mock data `<file>_test.go` under `internal/packetfabric`
-        * using real data `<resource_name>_test.go` under `internal/provider` 
+        * using real data `<resource_name>_test.go` under `internal/provider` (see [ACC](https://github.com/PacketFabric/terraform-provider-packetfabric#acceptance-tests))
     * Add/Update examples under `examples/resources` and/or `examples/data-sources` (used for the documentation)
     * Add/Update the templates used to generate the docs  under `templates`
-    * Generate the docs using tfplugindocs
+    * Generate the docs using tfplugindocs (or update the necessary `*md` under `docs/`)
     * Find more details on the [Readme](https://github.com/PacketFabric/terraform-provider-packetfabric).
 
 * Create your own branch with your updates including code changes, test, examples and documentation. 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ export PF_ACC_TEST_ROUTING_ID="PD-WUY-9VB0"
 export PF_ACC_TEST_MARKET="HOU"
 ```
 
-Then you can safely run the following command:
+> **Warning**: Running below command will order various PacketFabric products, then remove them.
+
+Then you can run the following command:
 
 ```shell
 make testacc

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ make testacc
 If you want to know the current list of acceptance tests available without executing them, run the following command:
 
 ```
-cd /working/internal/provider
+cd ./internal/provider
 go test -cover -v | grep -v testutil.go | grep -v github.com
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,12 +102,19 @@ export PF_ACC_TEST_ROUTING_ID="PD-WUY-9VB0"
 export PF_ACC_TEST_MARKET="HOU"
 ```
 
-> **Warning**: Running below command will order various PacketFabric products, then remove them.
+> **Warning**: Running below command will order various PacketFabric products, then delete them.
 
 Then you can run the following command:
 
 ```shell
 make testacc
+```
+
+If you want to know the current list of acceptance tests available without executing them, run the following command:
+
+```
+cd /working/internal/provider
+go test -cover -v | grep -v testutil.go | grep -v github.com
 ```
 
 ## Releasing the Provider


### PR DESCRIPTION
## Description

Add warning in ACC section's README to inform user running `make testacc` will create/delete services in PacketFabric platform.
