### PR TITLE
Add support Terraform Import to hosted/dedicated cloud

### DIFF
--- a/docs/resources/packetfabric_cs_aws_dedicated_connection.md
+++ b/docs/resources/packetfabric_cs_aws_dedicated_connection.md
@@ -81,6 +81,10 @@ Optional:
 - `read` (String)
 - `update` (String)
 
+## Import
 
+Import an AWS dedicated connection using its circuit ID.
 
-
+```bash
+terraform import packetfabric_cs_aws_dedicated_connection.cs_conn1_dedicated_aws PF-CC-WDC-NYC-1726496-PF
+```

--- a/docs/resources/packetfabric_cs_aws_hosted_connection.md
+++ b/docs/resources/packetfabric_cs_aws_hosted_connection.md
@@ -56,5 +56,10 @@ output "packetfabric_cs_aws_hosted_connection" {
 - `id` (String) The ID of this resource.
 
 
+## Import
 
+Import an AWS hosted connection using its circuit ID.
 
+```bash
+terraform import packetfabric_cs_aws_hosted_connection.cs_conn1_hosted_aws PF-CC-WDC-NYC-1726496-PF
+```

--- a/docs/resources/packetfabric_cs_google_hosted_connection.md
+++ b/docs/resources/packetfabric_cs_google_hosted_connection.md
@@ -68,6 +68,10 @@ Optional:
 - `update` (String)
 
 
+## Import
 
+Import an Google hosted connection using its circuit ID.
 
-
+```bash
+terraform import packetfabric_cs_google_hosted_connection.cs_conn1_hosted_google PF-CC-WDC-NYC-1726496-PF
+```

--- a/docs/resources/packetfabric_cs_oracle_hosted_connection.md
+++ b/docs/resources/packetfabric_cs_oracle_hosted_connection.md
@@ -67,4 +67,10 @@ Optional:
 - `read` (String)
 - `update` (String)
 
+## Import
 
+Import an Oracle hosted connection using its circuit ID.
+
+```bash
+terraform import packetfabric_cs_oracle_hosted_connection.cs_conn1_hosted_oracle PF-CC-WDC-NYC-1726496-PF
+```

--- a/docs/resources/packetfabric_point_to_point.md
+++ b/docs/resources/packetfabric_point_to_point.md
@@ -87,3 +87,11 @@ Optional:
 - `update` (String)
 
 
+
+## Import
+
+Import a point to point circuit using its circuit ID.
+
+```bash
+terraform import packetfabric_point_to_point.ptp1 PF-PD-PHX-LAX-1748043-PF
+```

--- a/internal/provider/resource_aws_request_dedicated_conn.go
+++ b/internal/provider/resource_aws_request_dedicated_conn.go
@@ -84,6 +84,9 @@ func resourceAwsReqDedicatedConn() *schema.Resource {
 				Description: "A base64 encoded string of a PDF of the LOA that AWS provided.\n\n\tExample: SSBhbSBhIFBERg==",
 			},
 		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }
 

--- a/internal/provider/resource_aws_request_hosted_conn.go
+++ b/internal/provider/resource_aws_request_hosted_conn.go
@@ -73,6 +73,9 @@ func resourceAwsRequestHostConn() *schema.Resource {
 				Description:  "The speed of the new connection.\n\n\tAvailable: 50Mbps 100Mbps 200Mbps 300Mbps 400Mbps 500Mbps 1Gbps 2Gbps 5Gbps 10Gbps",
 			},
 		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }
 

--- a/internal/provider/resource_google_hosted_mkt_conn.go
+++ b/internal/provider/resource_google_hosted_mkt_conn.go
@@ -76,9 +76,6 @@ func resourceGoogleHostedMktConn() *schema.Resource {
 				Description:  "The speed of the new connection.\n\n\tEnum: [\"50Mbps\", \"100Mbps\", \"200Mbps\", \"300Mbps\", \"400Mbps\", \"500Mbps\", \"1Gbps\", \"2Gbps\", \"5Gbps\", \"10Gbps\"]",
 			},
 		},
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
 	}
 }
 

--- a/internal/provider/resource_google_hosted_mkt_conn.go
+++ b/internal/provider/resource_google_hosted_mkt_conn.go
@@ -76,6 +76,9 @@ func resourceGoogleHostedMktConn() *schema.Resource {
 				Description:  "The speed of the new connection.\n\n\tEnum: [\"50Mbps\", \"100Mbps\", \"200Mbps\", \"300Mbps\", \"400Mbps\", \"500Mbps\", \"1Gbps\", \"2Gbps\", \"5Gbps\", \"10Gbps\"]",
 			},
 		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }
 

--- a/internal/provider/resource_google_request_hosted_conn.go
+++ b/internal/provider/resource_google_request_hosted_conn.go
@@ -80,6 +80,9 @@ func resourceGoogleRequestHostConn() *schema.Resource {
 				Description:  "The speed of the new connection.\n\n\t Available: 50Mbps 100Mbps 200Mbps 300Mbps 400Mbps 500Mbps 1Gbps 2Gbps 5Gbps 10Gbps",
 			},
 		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }
 

--- a/internal/provider/resource_oracle_hosted_conn.go
+++ b/internal/provider/resource_oracle_hosted_conn.go
@@ -87,6 +87,9 @@ func resourceOracleHostedConn() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "UUID of the published quote line with this connection should be associated.",
 			},
+			Importer: &schema.ResourceImporter{
+				StateContext: schema.ImportStatePassthroughContext,
+			},
 		},
 	}
 }

--- a/internal/provider/resource_oracle_hosted_conn.go
+++ b/internal/provider/resource_oracle_hosted_conn.go
@@ -87,9 +87,9 @@ func resourceOracleHostedConn() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "UUID of the published quote line with this connection should be associated.",
 			},
-			Importer: &schema.ResourceImporter{
-				StateContext: schema.ImportStatePassthroughContext,
-			},
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }

--- a/templates/resources/cs_aws_dedicated_connection.md.tmpl
+++ b/templates/resources/cs_aws_dedicated_connection.md.tmpl
@@ -16,3 +16,10 @@ A port located in an AWS cloud on-ramp facility, which will be connected to the 
 
 {{ .SchemaMarkdown }}
 
+## Import
+
+Import an AWS dedicated connection using its circuit ID.
+
+```bash
+terraform import packetfabric_cs_aws_dedicated_connection.cs_conn1_dedicated_aws PF-CC-WDC-NYC-1726496-PF
+```

--- a/templates/resources/cs_aws_hosted_connection.md.tmpl
+++ b/templates/resources/cs_aws_hosted_connection.md.tmpl
@@ -18,3 +18,10 @@ A hosted cloud connection to your AWS environment. For more information, see [Cl
 {{ .SchemaMarkdown }}
 
 
+## Import
+
+Import an AWS hosted connection using its circuit ID.
+
+```bash
+terraform import packetfabric_cs_aws_hosted_connection.cs_conn1_hosted_aws PF-CC-WDC-NYC-1726496-PF
+```

--- a/templates/resources/cs_google_hosted_connection.md.tmpl
+++ b/templates/resources/cs_google_hosted_connection.md.tmpl
@@ -17,4 +17,10 @@ A hosted cloud connection to your Google Cloud environment. For more information
 
 {{ .SchemaMarkdown }}
 
+## Import
 
+Import an Google hosted connection using its circuit ID.
+
+```bash
+terraform import packetfabric_cs_google_hosted_connection.cs_conn1_hosted_google PF-CC-WDC-NYC-1726496-PF
+```

--- a/templates/resources/cs_oracle_hosted_connection.md.tmpl
+++ b/templates/resources/cs_oracle_hosted_connection.md.tmpl
@@ -16,3 +16,11 @@ description: |-
 {{tffile "examples/resources/packetfabric_cs_oracle_hosted_connection/resource.tf"}}
 
 {{ .SchemaMarkdown }}
+
+## Import
+
+Import an Oracle hosted connection using its circuit ID.
+
+```bash
+terraform import packetfabric_cs_oracle_hosted_connection.cs_conn1_hosted_oracle PF-CC-WDC-NYC-1726496-PF
+```

--- a/templates/resources/point_to_point.md.tmpl
+++ b/templates/resources/point_to_point.md.tmpl
@@ -15,3 +15,11 @@ A point to point connection is an Ethernet Private Line between two access ports
 {{tffile "examples/resources/packetfabric_point_to_point/resource.tf"}}
 
 {{ .SchemaMarkdown }}
+
+## Import
+
+Import a point to point circuit using its circuit ID.
+
+```bash
+terraform import packetfabric_point_to_point.ptp1 PF-PD-PHX-LAX-1748043-PF
+```


### PR DESCRIPTION
## Description

Updated docs for `packetfabric_point_to_point` which is already supporting [terraform import](https://developer.hashicorp.com/terraform/cli/import/importability) in **v0.4**.

Added Terraform import for the following resources:

- `packetfabric_cs_aws_hosted_connection`
- `packetfabric_cs_aws_dedicated_connection`
- `packetfabric_cs_google_hosted_connection`
- `packetfabric_cs_oracle_hosted_connection`

## Checklist

- [x] tested locally
- [ ] added/updated acceptance tests
- [x] add examples (in example folder)
- [x] generate docs
