### PR TITLE
Update BGP session update function with PUT instead of PATCH

### DIFF
--- a/internal/packetfabric/bgp_session.go
+++ b/internal/packetfabric/bgp_session.go
@@ -200,7 +200,7 @@ func (c *PFClient) GetBgpSessionBy(cID, cloudConnID, bgpSettingsUUID string) (*B
 func (c *PFClient) UpdateBgpSession(bgpSession BgpSession, cID, connCID string) (*http.Response, *BgpSessionCreateResp, error) {
 	formatedURI := fmt.Sprintf(bgpSessionCloudRouterURI, cID, connCID)
 	expectedResp := &BgpSessionCreateResp{}
-	resp, err := c.sendRequest(formatedURI, patchMethod, bgpSession, expectedResp)
+	resp, err := c.sendRequest(formatedURI, putMethod, bgpSession, expectedResp)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Description

Update HTTP method from PATCH to PUT for BGP session update as per [API spec](https://docs.packetfabric.com/api/v2/swagger/#/BGP%20Session%20Settings).

Closes #264

## Checklist

- [x] tested locally
