### PR TITLE
Rename PF_ACCOUNT_UUID to PF_ACCOUNT_ID in ACC

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ environmental variables:
 ```shell
 export PF_HOST="https://api.packetfabric.com"
 export PF_TOKEN="api-secret"
-export PF_ACCOUNT_UUID="1234"
+export PF_ACCOUNT_ID="1234"
 export PF_ACC_TEST_ROUTING_ID="PD-WUY-9VB0"
 export PF_ACC_TEST_MARKET="HOU"
 export PF_AWS_ACCOUNT_ID="123456789"

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -23,7 +23,7 @@ func GenerateUniqueResourceName() string {
 }
 
 func GetAccountUUID() string {
-	return os.Getenv("PF_ACCOUNT_UUID")
+	return os.Getenv("PF_ACCOUNT_ID")
 }
 
 func GetPopAndZoneWithAvailablePort(speed string) (string, string, error) {
@@ -56,7 +56,7 @@ func PreCheck(t *testing.T, additionalEnvVars []string) {
 	requiredEnvVars := []string{
 		"PF_HOST",
 		"PF_TOKEN",
-		"PF_ACCOUNT_UUID",
+		"PF_ACCOUNT_ID",
 	}
 	if additionalEnvVars != nil {
 		requiredEnvVars = append(requiredEnvVars, additionalEnvVars...)


### PR DESCRIPTION
## Description

We called the PacketFabric Account ID `PF_ACCOUNT_ID` starting `v0.4.2`. Let's rename `PF_ACCOUNT_UUID` to `PF_ACCOUNT_ID` in the ACC to be align.

## Checklist

- [x] tested locally
