### PR TITLE
Adding PF_ACC_TEST_IX_ROUTING_ID and PF_ACC_TEST_IX_MARKET

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,12 @@ environmental variables:
 export PF_HOST="https://api.packetfabric.com"
 export PF_TOKEN="api-secret"
 export PF_ACCOUNT_ID="1234"
-export PF_ACC_TEST_ROUTING_ID="PD-WUY-9VB0"
-export PF_ACC_TEST_MARKET="HOU"
 export PF_AWS_ACCOUNT_ID="123456789"
 export PF_IBM_ACCOUNT_ID="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+export PF_ACC_TEST_ROUTING_ID="PD-WUY-9VB0"
+export PF_ACC_TEST_MARKET="BOS"
+export PF_ACC_TEST_IX_ROUTING_ID="PD-WUY-9VB0"
+export PF_ACC_TEST_IX_MARKET="HOU"
 ```
 
 > **Warning**: Running below command will order various PacketFabric products, then delete them.

--- a/internal/provider/resource_ix_vc_test.go
+++ b/internal/provider/resource_ix_vc_test.go
@@ -56,8 +56,8 @@ func TestAccIxVc(t *testing.T) {
 		pop,
 		zone,
 		description,
-		os.Getenv("PF_ACC_TEST_ROUTING_ID"), // TODO(medzin): Refactor to use the data from the customer endpoint.
-		os.Getenv("PF_ACC_TEST_MARKET"),     // TODO(medzin): Refactor to use the data from the customer endpoint.
+		os.Getenv("PF_ACC_TEST_IX_ROUTING_ID"), // TODO(medzin): Refactor to use the data from the customer endpoint.
+		os.Getenv("PF_ACC_TEST_IX_MARKET"),     // TODO(medzin): Refactor to use the data from the customer endpoint.
 		"12345",
 		"5",
 		testutil.GetAccountUUID(),
@@ -66,8 +66,8 @@ func TestAccIxVc(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testutil.PreCheck(t, []string{
-				"PF_ACC_TEST_ROUTING_ID",
-				"PF_ACC_TEST_MARKET",
+				"PF_ACC_TEST_IX_ROUTING_ID",
+				"PF_ACC_TEST_IX_MARKET",
 			})
 		},
 		Providers: testAccProviders,


### PR DESCRIPTION
## Description

Adding separate variables for IX service testing.

## Checklist

- [x] tested locally
