### PR TITLE
Deprecate device_id and site_id and correct optics_diagnostics_lane_values.lane_index in packetfabric_port_device_info

### DIFF
--- a/docs/data-sources/packetfabric_port_device_info.md
+++ b/docs/data-sources/packetfabric_port_device_info.md
@@ -35,7 +35,6 @@ output "packetfabric_port_device_info" {
 - `admin_status` (String) The current admin status.
 - `auto_negotiation` (Boolean) True if auto negotiation is on.
 - `device_can_lag` (Boolean) True if device can lag.
-- `device_id` (Number) The device ID.
 - `device_make` (String) The device make name.
 - `device_name` (String) The device name.
 - `iface_name` (String) The interface name.
@@ -50,7 +49,6 @@ output "packetfabric_port_device_info" {
 - `optics_diagnostics_lane_tx_power_dbm` (Number) The optics diagnostics lane TX Power dbm.
 - `optics_diagnostics_lane_tx_status` (String) The optics diagnostics lane tx status.
 - `polltime` (Number) The port pool time.
-- `site_id` (Number) The site ID.
 - `speed` (String) The port speed.
 - `time_flapped` (String) The port time flapped.
 - `traffic_rx_bps` (Number) The port traffic RX bps.

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -127,12 +127,22 @@ resource "random_pet" "name" {}
 
 # data "packetfabric_port_router_logs" "port_1a_logs" {
 #   provider        = packetfabric
-#   port_circuit_id = "PF-AP-WDC1-1726464" #packetfabric_port.port_1a.id
+#   port_circuit_id = packetfabric_port.port_1a.id
 #   time_from       = "2022-11-30 00:00:00"
 #   time_to         = "2022-12-01 00:00:00"
+#   depends_on = [packetfabric_port.port_1]
 # }
 # output "packetfabric_port_router_logs" {
 #   value = data.packetfabric_port_router_logs.port_1a_logs
+# }
+
+# data "packetfabric_port_device_info" "port_1a_device_info" {
+#   provider        = packetfabric
+#   port_circuit_id = packetfabric_port.port_1a.id
+#   depends_on = [packetfabric_port.port_1]
+# }
+# output "packetfabric_port_device_info" {
+#   value = data.packetfabric_port_device_info.port_1a_device_info
 # }
 
 # #######################################

--- a/internal/packetfabric/interfaces.go
+++ b/internal/packetfabric/interfaces.go
@@ -147,7 +147,6 @@ type PortVlanSummary struct {
 
 type PortDeviceInfo struct {
 	AdjacentRouter              interface{}                   `json:"adjacent_router,omitempty"`
-	DeviceID                    int                           `json:"device_id,omitempty"`
 	DeviceName                  string                        `json:"device_name,omitempty"`
 	DeviceMake                  string                        `json:"device_make,omitempty"`
 	AdminStatus                 string                        `json:"admin_status,omitempty"`
@@ -155,7 +154,6 @@ type PortDeviceInfo struct {
 	AutoNegotiation             bool                          `json:"auto_negotiation,omitempty"`
 	IfaceName                   string                        `json:"iface_name,omitempty"`
 	Speed                       string                        `json:"speed,omitempty"`
-	SiteID                      int                           `json:"site_id,omitempty"`
 	OpticsDiagnosticsLaneValues []OpticsDiagnosticsLaneValues `json:"optics_diagnostics_lane_values,omitempty"`
 	Polltime                    interface{}                   `json:"polltime,omitempty"`
 	TimeFlapped                 string                        `json:"time_flapped,omitempty"`
@@ -184,7 +182,7 @@ type PortDeviceInfo struct {
 type OpticsDiagnosticsLaneValues struct {
 	TxPowerDbm  float64 `json:"tx_power_dbm,omitempty"`
 	TxPower     float64 `json:"tx_power,omitempty"`
-	LaneIndex   float64 `json:"lane_index,omitempty"`
+	LaneIndex   string  `json:"lane_index,omitempty"`
 	RxPower     float64 `json:"rx_power,omitempty"`
 	RxPowerDbm  float64 `json:"rx_power_dbm,omitempty"`
 	BiasCurrent float64 `json:"bias_current,omitempty"`

--- a/internal/provider/datasource_port_device_info.go
+++ b/internal/provider/datasource_port_device_info.go
@@ -24,11 +24,6 @@ func dataSourcePortDeviceInfo() *schema.Resource {
 				Optional:    true,
 				Description: "The adjcent router.",
 			},
-			"device_id": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The device ID.",
-			},
 			"device_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -64,11 +59,6 @@ func dataSourcePortDeviceInfo() *schema.Resource {
 				Optional:    true,
 				Description: "The port speed.",
 			},
-			"site_id": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The site ID.",
-			},
 			"optics_diagnostics_lane_tx_power_dbm": {
 				Type:        schema.TypeFloat,
 				Optional:    true,
@@ -80,7 +70,7 @@ func dataSourcePortDeviceInfo() *schema.Resource {
 				Description: "The optics diagnostics lane TX Power.",
 			},
 			"optics_diagnostics_lane_index": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The optics diagnostics lane Index.",
 			},
@@ -239,7 +229,6 @@ func dataSourcePortDeviceInfoRead(ctx context.Context, d *schema.ResourceData, m
 		if portInfo.AdjacentRouter != nil {
 			_ = d.Set("adjacent_router", portInfo.AdjacentRouter)
 		}
-		_ = d.Set("device_id", portInfo.DeviceID)
 		_ = d.Set("device_name", portInfo.DeviceName)
 		_ = d.Set("device_make", portInfo.DeviceMake)
 		_ = d.Set("admin_status", portInfo.AdminStatus)
@@ -247,7 +236,6 @@ func dataSourcePortDeviceInfoRead(ctx context.Context, d *schema.ResourceData, m
 		_ = d.Set("auto_negotiation", portInfo.AutoNegotiation)
 		_ = d.Set("iface_name", portInfo.IfaceName)
 		_ = d.Set("speed", portInfo.Speed)
-		_ = d.Set("site_id", portInfo.SiteID)
 		for _, optics := range portInfo.OpticsDiagnosticsLaneValues {
 			_ = d.Set("optics_diagnostics_lane_tx_power_dbm", optics.TxPowerDbm)
 			_ = d.Set("optics_diagnostics_lane_tx_power", optics.TxPower)

--- a/internal/provider/datasource_port_device_info_test.go
+++ b/internal/provider/datasource_port_device_info_test.go
@@ -44,7 +44,6 @@ func TestAccDataSourcePortDeviceInfo(t *testing.T) {
 			{
 				Config: hcl,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "device_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "device_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "device_make"),
 					resource.TestCheckResourceAttrSet(resourceName, "admin_status"),
@@ -52,7 +51,6 @@ func TestAccDataSourcePortDeviceInfo(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "auto_negotiation"),
 					resource.TestCheckResourceAttrSet(resourceName, "iface_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "speed"),
-					resource.TestCheckResourceAttrSet(resourceName, "site_id"),
 				),
 			},
 		},


### PR DESCRIPTION
## Description

Closes #290

## Checklist

- [x] tested locally
- [x] added/updated acceptance tests
- [x] generate docs
