### PR TITLE
Fix packetfabric_activitylog data-source

### DIFF
--- a/docs/data-sources/packetfabric_activitylog.md
+++ b/docs/data-sources/packetfabric_activitylog.md
@@ -40,6 +40,7 @@ Optional:
 - `category` (String) The log Category.
 - `event` (String) The log Event.
 - `level` (Number) The log level.
+- `log_level_name` (String) The log level name.
 - `log_uuid` (String) The log UUID.
 - `message` (String) The log Message.
 - `time_created` (String) The log time created.

--- a/internal/packetfabric/activity_log.go
+++ b/internal/packetfabric/activity_log.go
@@ -1,5 +1,7 @@
 package packetfabric
 
+import "fmt"
+
 const activityLogsURI = "/v2/activity-logs"
 
 type ActivityLog struct {
@@ -10,13 +12,22 @@ type ActivityLog struct {
 	Event       string `json:"event,omitempty"`
 	Message     string `json:"message,omitempty"`
 	TimeCreated string `json:"time_created,omitempty"`
+	LevelName   string `json:"log_level_name,omitempty"`
 }
 
-func (c *PFClient) GetActivityLogs() (*[]ActivityLog, error) {
+func (c *PFClient) GetActivityLogs() ([]ActivityLog, error) {
 	expectedResp := make([]ActivityLog, 0)
 	_, err := c.sendRequest(activityLogsURI, getMethod, nil, expectedResp)
 	if err != nil {
 		return nil, err
 	}
 	return &expectedResp, nil
+}
+
+func (c *PFClient) GetCloudRouterRequests(reqType string) ([]CloudRouterRequest, error) {
+	cloudRouterRequests := make([]CloudRouterRequest, 0)
+	if _, err := c.sendRequest(fmt.Sprintf(cloudRouterRequestsURI, reqType), getMethod, nil, &cloudRouterRequests); err != nil {
+		return nil, err
+	}
+	return cloudRouterRequests, nil
 }

--- a/internal/packetfabric/activity_log.go
+++ b/internal/packetfabric/activity_log.go
@@ -1,7 +1,5 @@
 package packetfabric
 
-import "fmt"
-
 const activityLogsURI = "/v2/activity-logs"
 
 type ActivityLog struct {
@@ -17,17 +15,9 @@ type ActivityLog struct {
 
 func (c *PFClient) GetActivityLogs() ([]ActivityLog, error) {
 	expectedResp := make([]ActivityLog, 0)
-	_, err := c.sendRequest(activityLogsURI, getMethod, nil, expectedResp)
+	_, err := c.sendRequest(activityLogsURI, getMethod, nil, &expectedResp)
 	if err != nil {
 		return nil, err
 	}
-	return &expectedResp, nil
-}
-
-func (c *PFClient) GetCloudRouterRequests(reqType string) ([]CloudRouterRequest, error) {
-	cloudRouterRequests := make([]CloudRouterRequest, 0)
-	if _, err := c.sendRequest(fmt.Sprintf(cloudRouterRequestsURI, reqType), getMethod, nil, &cloudRouterRequests); err != nil {
-		return nil, err
-	}
-	return cloudRouterRequests, nil
+	return expectedResp, nil
 }

--- a/internal/provider/datasource_activity_log.go
+++ b/internal/provider/datasource_activity_log.go
@@ -83,7 +83,7 @@ func datasourceActivityLogRead(ctx context.Context, d *schema.ResourceData, m in
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if err = d.Set("activity_logs", flattenActivityLogs(activityLogs)); err != nil {
+	if err = d.Set("activity_logs", flattenActivityLogs(&activityLogs)); err != nil {
 		return diag.FromErr(err)
 	}
 	d.SetId(uuid.New().String())
@@ -100,7 +100,7 @@ func flattenActivityLogs(logs *[]packetfabric.ActivityLog) []interface{} {
 			flatten["level"] = log.Level
 			flatten["category"] = log.Category
 			flatten["event"] = log.Event
-			flatten["messge"] = log.Message
+			flatten["message"] = log.Message
 			flatten["time_created"] = log.TimeCreated
 			flatten["log_level_name"] = log.LevelName
 			flattens[i] = flatten

--- a/internal/provider/datasource_activity_log.go
+++ b/internal/provider/datasource_activity_log.go
@@ -62,6 +62,12 @@ func datasourceActivityLog() *schema.Resource {
 							Optional:    true,
 							Description: "The log time created.",
 						},
+						"log_level_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Optional:    true,
+							Description: "The log level name.",
+						},
 					},
 				},
 			},
@@ -96,6 +102,7 @@ func flattenActivityLogs(logs *[]packetfabric.ActivityLog) []interface{} {
 			flatten["event"] = log.Event
 			flatten["messge"] = log.Message
 			flatten["time_created"] = log.TimeCreated
+			flatten["log_level_name"] = log.LevelName
 			flattens[i] = flatten
 		}
 		return flattens


### PR DESCRIPTION
## Description

- fix typo `messge` to `message` in packetfabric_activitylog go code
- add `log_level_name` field

## Checklist

- [x] tested locally
- [x] added/updated examples (in example folder)
- [x] added/updated docs
