### PR TITLE
Handle json.Unmarshal errors in unit tests

### DIFF
--- a/internal/packetfabric/bgp_session_test.go
+++ b/internal/packetfabric/bgp_session_test.go
@@ -60,8 +60,12 @@ func init() {
 func Test_CreateBgpSession(t *testing.T) {
 	expectedPayload := BgpSession{}
 	expectedResp := BgpSessionCreateResp{}
-	_ = json.Unmarshal(_buildBgpSessionPayload(), &expectedPayload)
-	_ = json.Unmarshal(_buildBgpSessionCreateResp(), &expectedResp)
+	if err := json.Unmarshal(_buildBgpSessionPayload(), &expectedPayload); err != nil {
+		t.Fatalf("Failed to unmarshal BgpSession: %s", err)
+	}
+	if err := json.Unmarshal(_buildBgpSessionCreateResp(), &expectedResp); err != nil {
+		t.Fatalf("Failed to unmarshal BgpSessionCreateResp: %s", err)
+	}
 	cTest.runFakeHttpServer(_callCreateBgpSession, expectedPayload, expectedResp, _buildBgpSessionCreateResp(), "bgp-session-create", t)
 }
 
@@ -96,8 +100,8 @@ func _buildBgpSessionPayload() []byte {
 				"type": "in",
 				"local_preference": 100,
 				"order": 1
-			},
-		],
+			}
+		]
 	}`, _bgpMd5, _bgpL3Prefix, _bgpRemoteAddress, _bgpRemoteAsn, _bgpPrefixOut, _bgpPrefixIn))
 }
 

--- a/internal/packetfabric/cloud_router_connection_test.go
+++ b/internal/packetfabric/cloud_router_connection_test.go
@@ -74,8 +74,12 @@ func init() {
 func Test_CreateAwsConn(t *testing.T) {
 	var payload AwsConnection
 	var expectedResp AwsConnectionCreateResponse
-	_ = json.Unmarshal(_buildMockCloudRouterConnectionCreate(), &payload)
-	_ = json.Unmarshal(_buildMockCloudRouterCreateResp(), &expectedResp)
+	if err := json.Unmarshal(_buildMockCloudRouterConnectionCreate(), &payload); err != nil {
+		t.Fatalf("Failed to unmarshal AwsConnection: %s", err)
+	}
+	if err := json.Unmarshal(_buildMockCloudRouterCreateResp(), &expectedResp); err != nil {
+		t.Fatalf("Failed to unmarshal AwsConnectionCreateResponse: %s", err)
+	}
 	cTest.runFakeHttpServer(_callCreateAwsConn, payload, expectedResp, _buildMockCloudRouterCreateResp(), "-test-create-aws-conn", t)
 }
 
@@ -92,26 +96,33 @@ func Test_UpdateCloudRouterConnection(t *testing.T) {
 	payload := DescriptionUpdate{
 		Description: _cloudConnUpdateDesc,
 	}
-	_ = json.Unmarshal(_buildMockCloudRouterConnResp(_cloudConnUpdateDesc), &expectedResp)
+	if err := json.Unmarshal(_buildMockCloudRouterConnResp(_cloudConnUpdateDesc), &expectedResp); err != nil {
+		t.Fatalf("Failed to unmarshal CloudRouterConnectionReadResponse: %s", err)
+	}
 	cTest.runFakeHttpServer(_callUpdateAwsConn, payload, expectedResp, _buildMockCloudRouterConnResp(_cloudConnUpdateDesc), "aws-cloud-router-conn-update", t)
 }
 
 func Test_GetCloudConnectionStatus(t *testing.T) {
 	var expectedResp ServiceState
-	_ = json.Unmarshal(_buildMockCloudRouterConnStatus(), &expectedResp)
+	if err := json.Unmarshal(_buildMockCloudRouterConnStatus(), &expectedResp); err != nil {
+		t.Fatalf("Failed to unmarshal ServiceState: %s", err)
+	}
 	cTest.runFakeHttpServer(_callGetClouConnectionStatus, nil, expectedResp, _buildMockCloudRouterConnStatus(), "aws-cloud-router-conn-get-status", t)
 }
 
 func Test_ListAwsRouterConnections(t *testing.T) {
 	var expectedResp []CloudRouterConnectionReadResponse
-	_ = json.Unmarshal(_buildMockCloudRouterConnResps(), &expectedResp)
+	if err := json.Unmarshal(_buildMockCloudRouterConnResps(), &expectedResp); err != nil {
+		t.Fatalf("Failed to unmarshal []CloudRouterConnectionReadResponse: %s", err)
+	}
 	cTest.runFakeHttpServer(_callListAwsRouterConnections, nil, expectedResp, _buildMockCloudRouterConnResps(), "aws-cloud-router-conns", t)
-
 }
 
 func Test_DeleteCloudRouterConnection(t *testing.T) {
 	var expectedResp ConnectionDeleteResp
-	_ = json.Unmarshal(_buildConnDeleteResp(), &expectedResp)
+	if err := json.Unmarshal(_buildConnDeleteResp(), &expectedResp); err != nil {
+		t.Fatalf("Failed to unmarshal ConnectionDeleteResp: %s", err)
+	}
 	cTest.runFakeHttpServer(_callDeleteAwsConn, nil, expectedResp, _buildConnDeleteResp(), "test-delete-aws-connection", t)
 }
 

--- a/internal/packetfabric/cloud_router_test.go
+++ b/internal/packetfabric/cloud_router_test.go
@@ -69,7 +69,9 @@ func Test_ReadCloudRouter(t *testing.T) {
 
 func Test_ListCloudRouters(t *testing.T) {
 	var expectedResp []CloudRouterResponse
-	_ = json.Unmarshal(_buildMockCloudRouterResps(), &expectedResp)
+	if err := json.Unmarshal(_buildMockCloudRouterResps(), &expectedResp); err != nil {
+		t.Fatalf("Failed to unmarshal []CloudRouterResponse: %s", err)
+	}
 	cTest.runFakeHttpServer(_callListCloudRouters, nil, expectedResp, _buildMockCloudRouterResps(), "list-cloud-routers", t)
 }
 

--- a/internal/packetfabric/vc_backbone_test.go
+++ b/internal/packetfabric/vc_backbone_test.go
@@ -13,8 +13,12 @@ const _portCircuitIDTwo = "PF-AP-LAS1-2000"
 func Test_CreateBackbone(t *testing.T) {
 	expectedPayload := Backbone{}
 	expectedResp := BackboneResp{}
-	_ = json.Unmarshal(_buildCreateBackbonePayload(_backboneDesc), &expectedPayload)
-	_ = json.Unmarshal(_buildCreateBackBoneResp(_backboneDesc, _awsAccountID), &expectedResp)
+	if err := json.Unmarshal(_buildCreateBackbonePayload(_backboneDesc), &expectedPayload); err != nil {
+		t.Fatalf("Failed to unmarshal Backbone: %s", err)
+	}
+	if err := json.Unmarshal(_buildCreateBackBoneResp(_backboneDesc, _awsAccountID), &expectedResp); err != nil {
+		t.Fatalf("Failed to unmarshal BackboneResp: %s", err)
+	}
 	cTest.runFakeHttpServer(_callCreateBackbone, expectedPayload, expectedResp, _buildCreateBackBoneResp(_backboneDesc, _awsAccountID), "backbone-create", t)
 }
 


### PR DESCRIPTION
Our unit tests use raw JSON strings where it's easy to make a typo. Ignoring these errors caused some tests to pass regardless.

- [x] tested locally
