### PR TITLE
Fix/remote address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.1  (February 10, 2023)
+
+IMPROVEMENTS/ENHANCEMENTS:
+
+* Cloud Router documentation updates
+
+BUG FIXES:
+
+* Set remote_address to omitempty in the BGP session schema to prevent sending and empty value
+
 ## 1.0.0  (February 8, 2023)
 
 BREAKING CHANGES:

--- a/internal/packetfabric/bgp_session.go
+++ b/internal/packetfabric/bgp_session.go
@@ -18,7 +18,7 @@ type BgpSession struct {
 	PrimarySubnet   string      `json:"primary_subnet,omitempty"`
 	SecondarySubnet string      `json:"secondary_subnet,omitempty"`
 	AddressFamily   string      `json:"address_family"`
-	RemoteAddress   string      `json:"remote_address"`
+	RemoteAddress   string      `json:"remote_address,omitempty"`
 	RemoteAsn       int         `json:"remote_asn"`
 	MultihopTTL     int         `json:"multihop_ttl,omitempty"`
 	LocalPreference int         `json:"local_preference,omitempty"`


### PR DESCRIPTION
## Description

Set remote_address to omitempty in the BGP session schema to prevent sending and empty value

## Checklist

- [x] tested locally
