### PR TITLE
Remove disable BGP session and add 20s delay after Azure CRC creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.3  (February 14, 2023)
+
+BUG FIXES:
+
+* Remove unecessary disable BGP session when deleting packetfabric_cloud_router_bgp_session (#334)
+* Add delay after Azure Cloud Router Connection is created (#334)
+
 ## 1.0.2  (February 12, 2023)
 
 BUG FIXES:

--- a/internal/provider/resource_azure_cloud_router_connection.go
+++ b/internal/provider/resource_azure_cloud_router_connection.go
@@ -118,7 +118,7 @@ func resourceAzureExpressRouteConnCreate(ctx context.Context, d *schema.Resource
 			d.SetId(resp.CloudCircuitID)
 		}
 		// Adding delay after Azure Cloud Router Connection created
-		time.Sleep(20 * time.Second)
+		time.Sleep(30 * time.Second)
 	} else {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,

--- a/internal/provider/resource_azure_cloud_router_connection.go
+++ b/internal/provider/resource_azure_cloud_router_connection.go
@@ -117,6 +117,8 @@ func resourceAzureExpressRouteConnCreate(ctx context.Context, d *schema.Resource
 		if resp != nil {
 			d.SetId(resp.CloudCircuitID)
 		}
+		// Adding delay after Azure Cloud Router Connection created
+		time.Sleep(20 * time.Second)
 	} else {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,

--- a/internal/provider/resource_bgp_session.go
+++ b/internal/provider/resource_bgp_session.go
@@ -330,8 +330,7 @@ func resourceBgpSessionDelete(ctx context.Context, d *schema.ResourceData, m int
 	diags = append(diags, diag.Diagnostic{
 		Severity: diag.Warning,
 		Summary:  "BGP session cannot be deleted.",
-		Detail: fmt.Sprintf("BGP with Settings UUID (%s) " +
-			"It will be deleted together with the Cloud Router Connection."),
+		Detail:   fmt.Sprintf("It will be deleted together with the Cloud Router Connection."),
 	})
 	d.SetId("")
 	return diags

--- a/internal/provider/resource_bgp_session.go
+++ b/internal/provider/resource_bgp_session.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/PacketFabric/terraform-provider-packetfabric/internal/packetfabric"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -330,7 +329,7 @@ func resourceBgpSessionDelete(ctx context.Context, d *schema.ResourceData, m int
 	diags = append(diags, diag.Diagnostic{
 		Severity: diag.Warning,
 		Summary:  "BGP session cannot be deleted.",
-		Detail:   fmt.Sprintf("It will be deleted together with the Cloud Router Connection."),
+		Detail:   "It will be deleted together with the Cloud Router Connection.",
 	})
 	d.SetId("")
 	return diags

--- a/internal/provider/resource_bgp_session.go
+++ b/internal/provider/resource_bgp_session.go
@@ -327,39 +327,12 @@ func resourceBgpSessionDelete(ctx context.Context, d *schema.ResourceData, m int
 	c := m.(*packetfabric.PFClient)
 	c.Ctx = ctx
 	var diags diag.Diagnostics
-	cID, ok := d.GetOk("circuit_id")
-	if !ok {
-		return diag.FromErr(errors.New("please provide a valid Circuit ID"))
-	}
-	connCID, ok := d.GetOk("connection_id")
-	if !ok {
-		return diag.FromErr(errors.New("please provide a valid Cloud Router Connection ID"))
-	}
-	sessionToDisable := extractBgpSession(d)
-	sessionToDisable.Disabled = true
-	_, resp, err := c.UpdateBgpSession(sessionToDisable, cID.(string), connCID.(string))
-	if err != nil {
-		return diag.FromErr(err)
-	} else {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "BGP session disabled (it cannot be deleted).",
-			Detail: fmt.Sprintf("BGP with Settings UUID (%s) "+
-				"has been disabled and it will be deleted together with the Cloud Router Connection. "+
-				"If you decide not to delete the Cloud Router Connection, "+
-				"use terraform import to add it back under Terraform management. ", resp.BgpSettingsUUID),
-		})
-	}
-	// check Cloud Router Connection status
-	disableOkCh := make(chan bool)
-	defer close(disableOkCh)
-	fn := func() (*packetfabric.ServiceState, error) {
-		return c.GetCloudConnectionStatus(cID.(string), connCID.(string))
-	}
-	go c.CheckServiceStatus(disableOkCh, fn)
-	if !<-disableOkCh {
-		return diag.FromErr(err)
-	}
+	diags = append(diags, diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  "BGP session cannot be deleted.",
+		Detail: fmt.Sprintf("BGP with Settings UUID (%s) " +
+			"It will be deleted together with the Cloud Router Connection."),
+	})
 	d.SetId("")
 	return diags
 }


### PR DESCRIPTION
## Description

* Remove unecessary disable BGP session when deleting packetfabric_cloud_router_bgp_session
* Add delay after Azure Cloud Router Connection is created 

## Checklist

- [x] tested locally
