### PR TITLE
Azure BGP session update: if l3Address is not set, set it based on the values of primarySubnet and secondarySubnet

### DIFF
--- a/docs/resources/packetfabric_cloud_router_bgp_session.md
+++ b/docs/resources/packetfabric_cloud_router_bgp_session.md
@@ -12,7 +12,7 @@ The BGP session information for a cloud router connection.
 
 For information specific to each cloud provider, see [the PacketFabric cloud router BGP documentation](https://docs.packetfabric.com/cr/bgp/).
 
-->**Note:** When creating a BGP session, ensure you are also adding the associated prefixes.
+->**Note:** When creating a BGP session, ensure you are also adding the associated prefixes. For Azure, only specify either the `primary_subnet` or the `secondary_subnet`.
 
 ## Example Usage
 
@@ -169,9 +169,9 @@ resource "packetfabric_cloud_router_bgp_session" "cr_bgp1" {
 - `multihop_ttl` (Number) The TTL of this session. The default is `1`. For Google Cloud connections, see [the PacketFabric doc](https://docs.packetfabric.com/cr/bgp/bgp_google/#ttl).
 - `nat` (Block Set, Max: 1) Translate the source or destination IP address. (see [below for nested schema](#nestedblock--nat))
 - `orlonger` (Boolean) Whether to use exact match or longer for all prefixes.
-- `primary_subnet` (String) Currently for Azure use only. Provide this as the primary subnet when creating an Azure cloud router connection.
+- `primary_subnet` (String) Currently for Azure use only. Provide this as the primary subnet when creating the primary Azure cloud router connection.
 - `remote_address` (String) The cloud-side router peer IP. Not used for Azure connections. Required for all other CSP.
-- `secondary_subnet` (String) Currently for Azure use only. Provide this as the secondary subnet when creating an Azure cloud router connection.
+- `secondary_subnet` (String) Currently for Azure use only. Provide this as the secondary subnet when creating the secondary Azure cloud router connection.
 
 ### Read-Only
 

--- a/examples/use-cases/cloud_router_google_azure/cloud_router_connection_azure.tf
+++ b/examples/use-cases/cloud_router_google_azure/cloud_router_connection_azure.tf
@@ -77,8 +77,8 @@ resource "packetfabric_cloud_router_bgp_session" "crbs_2" {
   multihop_ttl     = var.pf_crbs_mhttl
   remote_asn       = var.azure_side_asn1
   orlonger         = var.pf_crbs_orlonger
+  # Only specify either the primary_subnet OR the secondary_subnet
   primary_subnet   = var.azure_primary_peer_address_prefix
-  secondary_subnet = var.azure_secondary_peer_address_prefix
   prefixes {
     prefix = var.gcp_subnet_cidr1
     type   = "out" # Allowed Prefixes to Cloud

--- a/templates/resources/cloud_router_bgp_session.md.tmpl
+++ b/templates/resources/cloud_router_bgp_session.md.tmpl
@@ -12,7 +12,7 @@ The BGP session information for a cloud router connection.
 
 For information specific to each cloud provider, see [the PacketFabric cloud router BGP documentation](https://docs.packetfabric.com/cr/bgp/).
 
-->**Note:** When creating a BGP session, ensure you are also adding the associated prefixes.
+->**Note:** When creating a BGP session, ensure you are also adding the associated prefixes. For Azure, only specify either the `primary_subnet` or the `secondary_subnet`.
 
 ## Example Usage
 


### PR DESCRIPTION
## Description

Azure BGP session update: if l3Address is not set, set it based on the values of primarySubnet and secondarySubnet

## Checklist

- [x] tested locally
- [x] added/updated examples (in example folder)
- [x] added/updated docs
