### PR TITLE
Update defaults and schema description

### DIFF
--- a/docs/resources/packetfabric_backbone_virtual_circuit.md
+++ b/docs/resources/packetfabric_backbone_virtual_circuit.md
@@ -79,7 +79,7 @@ resource "packetfabric_backbone_virtual_circuit" "vc1" {
 
 	For more information on the difference between the two, see [Virtual Circuit Ethernet Features](https://docs.packetfabric.com/reference/specs/ethernet_features/).
 
-  Defaults: false
+	Defaults: false
 - `flex_bandwidth_id` (String) ID of the flex bandwidth container from which to subtract this VC's speed.
 - `rate_limit_in` (Number) The upper bound, in Mbps, by which to limit incoming data.
 - `rate_limit_out` (Number) The upper bound, in Mbps, by which to limit outgoing data.

--- a/docs/resources/packetfabric_cloud_router_bgp_session.md
+++ b/docs/resources/packetfabric_cloud_router_bgp_session.md
@@ -153,20 +153,20 @@ resource "packetfabric_cloud_router_bgp_session" "cr_bgp1" {
 
 ### Optional
 
-- `as_prepend` (Number) The BGP prepend value for this instance. Deprecated.
+- `as_prepend` (Number) The BGP prepend value for this instance. It is used when type = out.
 - `bfd_interval` (Number) If you are using BFD, this is the interval (in milliseconds) at which to send test packets to peers.
 
 	Available range is 3 through 30000.
 - `bfd_multiplier` (Number) If you are using BFD, this is the number of consecutive packets that can be lost before BFD considers a peer down and shuts down BGP.
 
 	Available range is 2 through 16.
-- `community` (Number) The BGP community for this instance. Deprecated.
+- `community` (Number) The BGP community for this instance.
 - `disabled` (Boolean) Whether this BGP session is disabled. Default is false.
 - `l3_address` (String) The L3 address of this instance. Not used for Azure connections. Required for all other CSP.
-- `local_preference` (Number) The local preference for this instance. When the same route is received in multiple locations, those with a higher local preference value are preferred by the cloud router. Deprecated.
+- `local_preference` (Number) The local preference for this instance. When the same route is received in multiple locations, those with a higher local preference value are preferred by the cloud router. It is used when type = in.
 - `md5` (String) The MD5 value of the authenticated BGP sessions. Required for AWS.
-- `med` (Number) The Multi-Exit Discriminator of this instance. When the same route is advertised in multiple locations, those with a lower MED are preferred by the peer AS. Deprecated.
-- `multihop_ttl` (Number) The TTL of this session. The default is `1`. For Google Cloud connections, see [the PacketFabric doc](https://docs.packetfabric.com/cr/bgp/bgp_google/#ttl).
+- `med` (Number) The Multi-Exit Discriminator of this instance. When the same route is advertised in multiple locations, those with a lower MED are preferred by the peer AS. It is used when type = out.
+- `multihop_ttl` (Number) The TTL of this session. The default is `1`. For Google Cloud connections, see [the PacketFabric doc](https://docs.packetfabric.com/cr/bgp/bgp_google/#ttl). Defaults: 1
 - `nat` (Block Set, Max: 1) Translate the source or destination IP address. (see [below for nested schema](#nestedblock--nat))
 - `orlonger` (Boolean) Whether to use exact match or longer for all prefixes.
 - `primary_subnet` (String) Currently for Azure use only. Provide this as the primary subnet when creating the primary Azure cloud router connection.
@@ -191,6 +191,8 @@ Optional:
 - `as_prepend` (Number) The BGP prepend value of this prefix. It is used when type = out.
 - `local_preference` (Number) The local_preference of this prefix. It is used when type = in.
 - `match_type` (String) The match type of this prefix.
+
+	Enum: `"exact"` `"orlonger"` `"longer"`
 - `med` (Number) The MED of this prefix. It is used when type = out.
 - `order` (Number) The order of this prefix against the others.
 

--- a/docs/resources/packetfabric_cloud_router_connection_google.md
+++ b/docs/resources/packetfabric_cloud_router_connection_google.md
@@ -66,7 +66,7 @@ output "packetfabric_cloud_router_connection_google" {
 ### Optional
 
 - `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection. Defaults: false
-- `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection.Defaults: false
+- `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection. Defaults: false
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/docs/resources/packetfabric_cloud_router_connection_port.md
+++ b/docs/resources/packetfabric_cloud_router_connection_port.md
@@ -57,7 +57,7 @@ output "packetfabric_cloud_router_connection_port" {
 - `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection. Defaults: false
 - `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection. Defaults: false
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
-- `untagged` (Boolean) Whether the interface should be untagged. Do not specify a VLAN if this is to be an untagged connection.Defaults: false
+- `untagged` (Boolean) Whether the interface should be untagged. Do not specify a VLAN if this is to be an untagged connection. Defaults: false
 - `vlan` (Number) Valid VLAN range is from 4-4094, inclusive.
 
 ### Read-Only

--- a/docs/resources/packetfabric_cs_aws_dedicated_connection.md
+++ b/docs/resources/packetfabric_cs_aws_dedicated_connection.md
@@ -39,7 +39,7 @@ output "packetfabric_cs_aws_dedicated_connection" {
 ### Required
 
 - `account_uuid` (String) The UUID for the billing account that should be billed. Can also be set with the PF_ACCOUNT_ID environment variable.
-- `autoneg` (Boolean) Whether the port auto-negotiates or not. This is currently only possible with 1Gbps ports and the request will fail if specified with 10Gbps.
+- `autoneg` (Boolean) Whether the port auto-negotiates or not. This is currently only possible with 1Gbps ports and the request will fail if specified with 10Gbps. Defaults: false
 - `aws_region` (String) The region that the new connection will connect to.
 
 	Example: us-west-1
@@ -62,7 +62,7 @@ output "packetfabric_cs_aws_dedicated_connection" {
 - `loa` (String) A base64 encoded string of a PDF of the LOA that AWS provided.
 
 	Example: SSBhbSBhIFBERg==
-- `should_create_lag` (Boolean) Create the dedicated connection as a LAG interface.
+- `should_create_lag` (Boolean) Create the dedicated connection as a LAG interface. Defaults: true
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The desired AWS availability zone of the new connection.
 

--- a/docs/resources/packetfabric_cs_aws_hosted_marketplace_connection.md
+++ b/docs/resources/packetfabric_cs_aws_hosted_marketplace_connection.md
@@ -40,6 +40,7 @@ output "packetfabric_cs_aws_hosted_marketplace_connection" {
 - `market` (String) The market code (e.g. "ATL" or "DAL") in which you would like the marketplace provider to provision their side of the connection.
 
 	If the marketplace provider has services published in the marketplace, you can use the PacketFabric portal to see which POPs they are in. Simply remove the number from the POP to get the market code (e.g. if they offer services in "DAL5", enter "DAL" for the market).
+- `pop` (String) The POP in which the hosted connection should be provisioned (the cloud on-ramp).
 - `routing_id` (String) The routing ID of the marketplace provider that will be receiving this request.
 
 	Example: TR-1RI-OQ85
@@ -50,7 +51,6 @@ output "packetfabric_cs_aws_hosted_marketplace_connection" {
 ### Optional
 
 - `description` (String) A brief description of this connection.
-- `pop` (String) The POP in which the hosted connection should be provisioned (the cloud on-ramp).
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The desired zone of the new connection
 

--- a/docs/resources/packetfabric_cs_google_dedicated_connection.md
+++ b/docs/resources/packetfabric_cs_google_dedicated_connection.md
@@ -49,7 +49,7 @@ output "packetfabric_cs_google_dedicated_connection" {
 
 ### Optional
 
-- `autoneg` (Boolean) Whether the port auto-negotiates or not. This is currently only possible with 1Gbps ports and the request will fail if specified with 10Gbps.
+- `autoneg` (Boolean) Whether the port auto-negotiates or not. This is currently only possible with 1Gbps ports and the request will fail if specified with 10Gbps. Defaults: false
 - `loa` (String) A base64 encoded string of a PDF of the LOA that Google provided.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/docs/resources/packetfabric_port.md
+++ b/docs/resources/packetfabric_port.md
@@ -60,11 +60,11 @@ output "packetfabric_port_1_details" {
 
 ### Optional
 
-- `autoneg` (Boolean) Only applicable to 1Gbps ports. Controls whether auto negotiation is on (true) or off (false). The request will fail if specified with 10Gbps.
-- `enabled` (Boolean) Change Port Admin Status. Set it to true when port is enabled, false when port is disabled. Default is true.Defaults: true
+- `autoneg` (Boolean) Only applicable to 1Gbps ports. Controls whether auto negotiation is on (true) or off (false). The request will fail if specified with 10Gbps. Defaults: false
+- `enabled` (Boolean) Change Port Admin Status. Set it to true when port is enabled, false when port is disabled. Defaults: true
 - `nni` (Boolean) Set this to true to provision an ENNI port. ENNI ports will use a nni_svlan_tpid value of 0x8100.
 
-	By default, ENNI ports are not available to all users. If you are provisioning your first ENNI port and are unsure if you have permission, contact support@packetfabric.com.
+	By default, ENNI ports are not available to all users. If you are provisioning your first ENNI port and are unsure if you have permission, contact support@packetfabric.com. Defaults: false
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) Availability zone of the port.
 

--- a/internal/provider/resource_aws_hosted_mkt.go
+++ b/internal/provider/resource_aws_hosted_mkt.go
@@ -66,7 +66,7 @@ func resourceAwsHostedMkt() *schema.Resource {
 			},
 			"pop": {
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 				Description:  "The POP in which the hosted connection should be provisioned (the cloud on-ramp).",

--- a/internal/provider/resource_aws_request_dedicated_conn.go
+++ b/internal/provider/resource_aws_request_dedicated_conn.go
@@ -76,7 +76,8 @@ func resourceAwsReqDedicatedConn() *schema.Resource {
 				Type:        schema.TypeBool,
 				Required:    true,
 				ForceNew:    true,
-				Description: "Whether the port auto-negotiates or not. This is currently only possible with 1Gbps ports and the request will fail if specified with 10Gbps.",
+				Default:     false,
+				Description: "Whether the port auto-negotiates or not. This is currently only possible with 1Gbps ports and the request will fail if specified with 10Gbps. ",
 			},
 			"speed": {
 				Type:        schema.TypeString,
@@ -88,7 +89,8 @@ func resourceAwsReqDedicatedConn() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "Create the dedicated connection as a LAG interface.",
+				Default:     true,
+				Description: "Create the dedicated connection as a LAG interface. ",
 			},
 			"loa": {
 				Type:        schema.TypeString,

--- a/internal/provider/resource_bgp_session.go
+++ b/internal/provider/resource_bgp_session.go
@@ -72,27 +72,28 @@ func resourceBgpSession() *schema.Resource {
 			"multihop_ttl": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The TTL of this session. The default is `1`. For Google Cloud connections, see [the PacketFabric doc](https://docs.packetfabric.com/cr/bgp/bgp_google/#ttl).",
+				Default:     1,
+				Description: "The TTL of this session. The default is `1`. For Google Cloud connections, see [the PacketFabric doc](https://docs.packetfabric.com/cr/bgp/bgp_google/#ttl). ",
 			},
 			"local_preference": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The local preference for this instance. When the same route is received in multiple locations, those with a higher local preference value are preferred by the cloud router. Deprecated.",
+				Description: "The local preference for this instance. When the same route is received in multiple locations, those with a higher local preference value are preferred by the cloud router. It is used when type = in.",
 			},
 			"med": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The Multi-Exit Discriminator of this instance. When the same route is advertised in multiple locations, those with a lower MED are preferred by the peer AS. Deprecated.",
+				Description: "The Multi-Exit Discriminator of this instance. When the same route is advertised in multiple locations, those with a lower MED are preferred by the peer AS. It is used when type = out.",
 			},
 			"community": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The BGP community for this instance. Deprecated.",
+				Description: "The BGP community for this instance.",
 			},
 			"as_prepend": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The BGP prepend value for this instance. Deprecated.",
+				Description: "The BGP prepend value for this instance. It is used when type = out.",
 			},
 			"orlonger": {
 				Type:        schema.TypeBool,
@@ -192,7 +193,7 @@ func resourceBgpSession() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"exact", "orlonger", "longer"}, true),
-							Description:  "The match type of this prefix.",
+							Description:  "The match type of this prefix.\n\n\tEnum: `\"exact\"` `\"orlonger\"` `\"longer\"`",
 						},
 						"as_prepend": {
 							Type:        schema.TypeInt,

--- a/internal/provider/resource_google_cloud_router_connection.go
+++ b/internal/provider/resource_google_cloud_router_connection.go
@@ -48,7 +48,7 @@ func resourceGoogleCloudRouterConn() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Default:     false,
-				Description: "Set this to true if you intend to use NAT on this connection.",
+				Description: "Set this to true if you intend to use NAT on this connection. ",
 			},
 			"maybe_dnat": {
 				Type:        schema.TypeBool,

--- a/internal/provider/resource_google_dedicated_conn.go
+++ b/internal/provider/resource_google_dedicated_conn.go
@@ -72,7 +72,8 @@ func resourceGoogleDedicatedConn() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "Whether the port auto-negotiates or not. This is currently only possible with 1Gbps ports and the request will fail if specified with 10Gbps.",
+				Default:     false,
+				Description: "Whether the port auto-negotiates or not. This is currently only possible with 1Gbps ports and the request will fail if specified with 10Gbps. ",
 			},
 			"speed": {
 				Type:         schema.TypeString,

--- a/internal/provider/resource_port_cloud_router_connection.go
+++ b/internal/provider/resource_port_cloud_router_connection.go
@@ -73,7 +73,7 @@ func resourceCustomerOwnedPortConn() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "Whether the interface should be untagged. Do not specify a VLAN if this is to be an untagged connection.",
+				Description: "Whether the interface should be untagged. Do not specify a VLAN if this is to be an untagged connection. ",
 			},
 			"speed": {
 				Type:         schema.TypeString,

--- a/internal/provider/resource_ports.go
+++ b/internal/provider/resource_ports.go
@@ -39,7 +39,8 @@ func resourceInterfaces() *schema.Resource {
 			"autoneg": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "Only applicable to 1Gbps ports. Controls whether auto negotiation is on (true) or off (false). The request will fail if specified with 10Gbps.",
+				Default:     false,
+				Description: "Only applicable to 1Gbps ports. Controls whether auto negotiation is on (true) or off (false). The request will fail if specified with 10Gbps. ",
 			},
 			"description": {
 				Type:         schema.TypeString,
@@ -58,7 +59,8 @@ func resourceInterfaces() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Description: "Set this to true to provision an ENNI port. ENNI ports will use a nni_svlan_tpid value of 0x8100.\n\n\tBy default, ENNI ports are not available to all users. If you are provisioning your first ENNI port and are unsure if you have permission, contact support@packetfabric.com.",
+				Default:     false,
+				Description: "Set this to true to provision an ENNI port. ENNI ports will use a nni_svlan_tpid value of 0x8100.\n\n\tBy default, ENNI ports are not available to all users. If you are provisioning your first ENNI port and are unsure if you have permission, contact support@packetfabric.com. ",
 			},
 			"pop": {
 				Type:         schema.TypeString,
@@ -91,7 +93,7 @@ func resourceInterfaces() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				Description: "Change Port Admin Status. Set it to true when port is enabled, false when port is disabled. Default is true.",
+				Description: "Change Port Admin Status. Set it to true when port is enabled, false when port is disabled. ",
 			},
 		},
 		Importer: &schema.ResourceImporter{


### PR DESCRIPTION
## Description

Update defaults and schema description for:
- `packetfabric_cloud_router_bgp_session` (`multihop_ttl` defaults to `1`)
- `packetfabric_cs_google_dedicated_connection` (`autoneg` default to `false`)
- `packetfabric_cs_aws_dedicated_connection` (`should_create_lag` defaults to `true`
- `packetfabric_port` (`nni` defaults to `false`, `autoneg` defaults to `false`)

Minor docs updates

## Checklist

- [x] tested locally
- [x] added/updated docs
