### PR TITLE
resource packetfabric_cs_aws_dedicated_connection: autoneg: Default cannot be set with Required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.6  (February 20, 2023)
+
+BUG FIXES:
+
+* resource packetfabric_cs_aws_dedicated_connection: autoneg: Default cannot be set with Required (#399)
+
 ## 1.0.5  (February 20, 2023)
 
 BREAKING CHANGES:

--- a/docs/resources/packetfabric_cs_aws_dedicated_connection.md
+++ b/docs/resources/packetfabric_cs_aws_dedicated_connection.md
@@ -39,7 +39,7 @@ output "packetfabric_cs_aws_dedicated_connection" {
 ### Required
 
 - `account_uuid` (String) The UUID for the billing account that should be billed. Can also be set with the PF_ACCOUNT_ID environment variable.
-- `autoneg` (Boolean) Whether the port auto-negotiates or not. This is currently only possible with 1Gbps ports and the request will fail if specified with 10Gbps. Defaults: false
+- `autoneg` (Boolean) Whether the port auto-negotiates or not. This is currently only possible with 1Gbps ports and the request will fail if specified with 10Gbps.
 - `aws_region` (String) The region that the new connection will connect to.
 
 	Example: us-west-1

--- a/internal/provider/resource_aws_request_dedicated_conn.go
+++ b/internal/provider/resource_aws_request_dedicated_conn.go
@@ -76,8 +76,7 @@ func resourceAwsReqDedicatedConn() *schema.Resource {
 				Type:        schema.TypeBool,
 				Required:    true,
 				ForceNew:    true,
-				Default:     false,
-				Description: "Whether the port auto-negotiates or not. This is currently only possible with 1Gbps ports and the request will fail if specified with 10Gbps. ",
+				Description: "Whether the port auto-negotiates or not. This is currently only possible with 1Gbps ports and the request will fail if specified with 10Gbps.",
 			},
 			"speed": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
## Description

Fix resource packetfabric_cs_aws_dedicated_connection: autoneg: Default cannot be set with Required

## Checklist

- [x] tested locally
