### PR TITLE
Add l3_address to bgp response

### DIFF
--- a/docs/data-sources/packetfabric_cloud_router_bgp_session.md
+++ b/docs/data-sources/packetfabric_cloud_router_bgp_session.md
@@ -57,6 +57,7 @@ Optional:
 - `community` (String) The BGP community for this instance. Deprecated.
 - `disabled` (Boolean) Whether this BGP session is disabled.
 		Default "false"
+- `l3_address` (String) The L3 address of this instance.
 - `local_preference` (Number) The preference for this instance. Deprecated.
 - `med` (Number) The Multi-Exit Discriminator of this instance. Deprecated.
 - `multihop_ttl` (Number) The TTL of this session.

--- a/docs/resources/packetfabric_cs_aws_dedicated_connection.md
+++ b/docs/resources/packetfabric_cs_aws_dedicated_connection.md
@@ -62,7 +62,6 @@ output "packetfabric_cs_aws_dedicated_connection" {
 - `loa` (String) A base64 encoded string of a PDF of the LOA that AWS provided.
 
 	Example: SSBhbSBhIFBERg==
-
 - `should_create_lag` (Boolean) Create the dedicated connection as a LAG interface. Defaults: true
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The desired AWS availability zone of the new connection.

--- a/internal/packetfabric/bgp_session.go
+++ b/internal/packetfabric/bgp_session.go
@@ -83,6 +83,7 @@ type BgpSessionCreateResp struct {
 	LocalPreference int         `json:"local_preference"`
 	Community       string      `json:"community"`
 	AsPrepend       int         `json:"as_prepend"`
+	L3Address       string      `json:"l3_address"`
 	Med             int         `json:"med"`
 	Md5             string      `json:"md5"`
 	Orlonger        bool        `json:"orlonger"`
@@ -132,6 +133,7 @@ type BgpSessionAssociatedResp struct {
 	Community       string      `json:"community"`
 	AsPrepend       int         `json:"as_prepend"`
 	Med             int         `json:"med"`
+	L3Address       string      `json:"l3_address"`
 	Orlonger        bool        `json:"orlonger"`
 	BfdInterval     int         `json:"bfd_interval"`
 	BfdMultiplier   int         `json:"bfd_multiplier"`

--- a/internal/provider/datasource_bgp_session.go
+++ b/internal/provider/datasource_bgp_session.go
@@ -84,6 +84,13 @@ func dataSourceBgpSession() *schema.Resource {
 							Optional:    true,
 							Description: "The Multi-Exit Discriminator of this instance. Deprecated.",
 						},
+
+						"l3_address": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "The L3 address of this instance.",
+						},
 						"orlonger": {
 							Type:        schema.TypeBool,
 							Computed:    true,
@@ -287,6 +294,7 @@ func flattenBgpSessions(sessions *[]packetfabric.BgpSessionAssociatedResp) []int
 			flatten["local_preference"] = session.LocalPreference
 			flatten["community"] = session.Community
 			flatten["as_prepend"] = session.AsPrepend
+			flatten["l3_address"] = session.L3Address
 			flatten["med"] = session.Med
 			flatten["orlonger"] = session.Orlonger
 			flatten["bfd_interval"] = session.BfdInterval


### PR DESCRIPTION
## Description

Add `l3_address` to bgp response impacting `packetfabric_cloud_router_bgp_session` resource and data-source

## Cross-reference

PSE-10579

## Checklist

- [x] tested locally
- [x] added/updated docs
