### PR TITLE
Fix/350 handle metro dedicated use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.7  (February 22, 2023)
+
+BUG FIXES:
+
+* Error: Status: 400, Metro VCs do not support upgrades or renewals (#350)
+
 ## 1.0.6  (February 20, 2023)
 
 BUG FIXES:

--- a/docs/resources/packetfabric_backbone_virtual_circuit.md
+++ b/docs/resources/packetfabric_backbone_virtual_circuit.md
@@ -95,12 +95,12 @@ resource "packetfabric_backbone_virtual_circuit" "vc1" {
 Required:
 
 - `account_uuid` (String) The UUID for the billing account that should be billed. Can also be set with the PF_ACCOUNT_ID environment variable.
-- `longhaul_type` (String) Dedicated (no limits or additional charges), usage-based (per transferred GB) or hourly billing.
-
-	Enum ["dedicated" "usage" "hourly"]
 
 Optional:
 
+- `longhaul_type` (String) Dedicated (no limits or additional charges), usage-based (per transferred GB) or hourly billing. Not applicable for Metro Dedicated.
+
+	Enum ["dedicated" "usage" "hourly"]
 - `speed` (String) The desired speed of the new connection. Only applicable if `longhaul_type` is "dedicated" or "hourly".
 
 	Enum: ["50Mbps" "100Mbps" "200Mbps" "300Mbps" "400Mbps" "500Mbps" "1Gbps" "2Gbps" "5Gbps" "10Gbps" "20Gbps" "30Gbps" "40Gbps" "50Gbps" "60Gbps" "80Gbps" "100Gbps"]

--- a/internal/provider/resource_backbone.go
+++ b/internal/provider/resource_backbone.go
@@ -58,8 +58,8 @@ func resourceBackbone() *schema.Resource {
 						},
 						"longhaul_type": {
 							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Dedicated (no limits or additional charges), usage-based (per transferred GB) or hourly billing.\n\n\tEnum [\"dedicated\" \"usage\" \"hourly\"]",
+							Optional:    true,
+							Description: "Dedicated (no limits or additional charges), usage-based (per transferred GB) or hourly billing. Not applicable for Metro Dedicated.\n\n\tEnum [\"dedicated\" \"usage\" \"hourly\"]",
 						},
 					},
 				},
@@ -204,6 +204,15 @@ func resourceBackboneRead(ctx context.Context, d *schema.ResourceData, m interfa
 			bandwidth := map[string]interface{}{
 				"account_uuid":      resp.Bandwidth.AccountUUID,
 				"longhaul_type":     resp.Bandwidth.LonghaulType,
+				"subscription_term": resp.Bandwidth.SubscriptionTerm,
+				"speed":             resp.Bandwidth.Speed,
+			}
+			bandwidthSet.Add(bandwidth)
+		}
+		// metro dedicated doesn't need longhaul_type
+		if resp.Bandwidth.LonghaulType == "" {
+			bandwidth := map[string]interface{}{
+				"account_uuid":      resp.Bandwidth.AccountUUID,
 				"subscription_term": resp.Bandwidth.SubscriptionTerm,
 				"speed":             resp.Bandwidth.Speed,
 			}


### PR DESCRIPTION
## Description

Handle metro dedicated use case where `longhaul_type` isn't required.

Example:

```
  bandwidth {
    speed             = "100Mbps"
    subscription_term = 1
  }
```

Closes #350

## Checklist

- [x] tested locally
- [x] added/updated docs
