### PR TITLE
Add rate_limit_in/out, flex_bandwidth_id to packetfabric_backbone_virtual_circuit read()

### DIFF
--- a/internal/packetfabric/services.go
+++ b/internal/packetfabric/services.go
@@ -24,8 +24,8 @@ type Backbone struct {
 	Description     string              `json:"description"`
 	Bandwidth       Bandwidth           `json:"bandwidth"`
 	Interfaces      []BackBoneInterface `json:"interfaces"`
-	RateLimitIn     int                 `json:"rate_limit_in"`
-	RateLimitOut    int                 `json:"rate_limit_out"`
+	RateLimitIn     int                 `json:"rate_limit_in,omitempty"`
+	RateLimitOut    int                 `json:"rate_limit_out,omitempty"`
 	Epl             bool                `json:"epl"`
 	FlexBandwidthID string              `json:"flex_bandwidth_id,omitempty"`
 }
@@ -56,20 +56,22 @@ type ServiceSettingsUpdate struct {
 }
 
 type BackboneResp struct {
-	VcCircuitID  string               `json:"vc_circuit_id"`
-	CustomerUUID string               `json:"customer_uuid"`
-	State        string               `json:"state"`
-	ServiceType  string               `json:"service_type"`
-	ServiceClass string               `json:"service_class"`
-	Mode         string               `json:"mode"`
-	Connected    bool                 `json:"connected"`
-	Bandwidth    Bandwidth            `json:"bandwidth"`
-	Description  string               `json:"description"`
-	RateLimitIn  int                  `json:"rate_limit_in"`
-	RateLimitOut int                  `json:"rate_limit_out"`
-	TimeCreated  string               `json:"time_created"`
-	TimeUpdated  string               `json:"time_updated"`
-	Interfaces   []BackboneInterfResp `json:"interfaces"`
+	VcCircuitID         string               `json:"vc_circuit_id"`
+	CustomerUUID        string               `json:"customer_uuid"`
+	State               string               `json:"state"`
+	ServiceType         string               `json:"service_type"`
+	ServiceClass        string               `json:"service_class"`
+	Mode                string               `json:"mode"`
+	AggregateCapacityID string               `json:"aggregate_capacity_id,omitempty"` // same as flex fandwidth
+	FlexBandwidthID     string               `json:"flex_bandwidth_id,omitempty"`
+	Connected           bool                 `json:"connected"`
+	Bandwidth           Bandwidth            `json:"bandwidth"`
+	Description         string               `json:"description"`
+	RateLimitIn         int                  `json:"rate_limit_in"`
+	RateLimitOut        int                  `json:"rate_limit_out"`
+	TimeCreated         string               `json:"time_created"`
+	TimeUpdated         string               `json:"time_updated"`
+	Interfaces          []BackboneInterfResp `json:"interfaces"`
 }
 
 type BackboneInterfResp struct {

--- a/internal/provider/resource_backbone.go
+++ b/internal/provider/resource_backbone.go
@@ -259,6 +259,13 @@ func resourceBackboneRead(ctx context.Context, d *schema.ResourceData, m interfa
 			interfaceZ["untagged"] = resp.Interfaces[1].Untagged
 			_ = d.Set("interface_z", []interface{}{interfaceZ})
 		}
+		if _, ok := d.GetOk("rate_limit_in"); ok {
+			_ = d.Set("rate_limit_in", resp.RateLimitIn)
+		}
+		if _, ok := d.GetOk("rate_limit_out"); ok {
+			_ = d.Set("rate_limit_out", resp.RateLimitOut)
+		}
+		_ = d.Set("flex_bandwidth_id", resp.AggregateCapacityID)
 	}
 	return diags
 }

--- a/internal/provider/resource_backbone.go
+++ b/internal/provider/resource_backbone.go
@@ -325,15 +325,11 @@ func resourceBackboneDelete(ctx context.Context, d *schema.ResourceData, m inter
 	c.Ctx = ctx
 	var diags diag.Diagnostics
 	if vcCircuitID, ok := d.GetOk("id"); ok {
-		resp, err := c.DeleteBackbone(vcCircuitID.(string))
+		_, err := c.DeleteBackbone(vcCircuitID.(string))
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "Backbone Delete result",
-			Detail:   resp.Message,
-		})
+		d.SetId("")
 		return diags
 	}
 	return diag.Errorf("please provide a valid VC Circuit ID for deletion")


### PR DESCRIPTION
## Description

- Add rate_limit_in/out, flex_bandwidth_id to packetfabric_backbone_virtual_circuit read function
- Removed unnecessary `Warning: Backbone Delete result` when deleting a Backbone VC


## Checklist

- [x] tested locally
