### PR TITLE
Deprecate order in packetfabric_cloud_router_bgp_session resource and data-source

### DIFF
--- a/docs/data-sources/packetfabric_cloud_router_bgp_session.md
+++ b/docs/data-sources/packetfabric_cloud_router_bgp_session.md
@@ -107,7 +107,7 @@ Optional:
 - `local_preference` (Number) The local_preference of the bgp prefix. It is used when type = in.
 - `match_type` (String) The prefix match type.
 - `med` (Number) The med of the bgp prefix. It is used when type = out.
-- `order` (Number) The order of the bgp prefix against the others.
+- `order` (Number, Deprecated) The order of the bgp prefix against the others.
 - `prefix` (String) The actual IP Prefix of the bgp prefix.
 - `type` (String) Indicates whether the prefix is in or out.
 

--- a/docs/resources/packetfabric_cloud_router_bgp_session.md
+++ b/docs/resources/packetfabric_cloud_router_bgp_session.md
@@ -52,22 +52,18 @@ resource "packetfabric_cloud_router_bgp_session" "cr_bgp1" {
   prefixes {
     prefix = var.pf_crbp_pfx00
     type   = "out" # Allowed Prefixes to Cloud
-    order  = var.pf_crbp_pfx00_order
   }
   prefixes {
     prefix = var.pf_crbp_pfx01
     type   = "out" # Allowed Prefixes to Cloud
-    order  = var.pf_crbp_pfx01_order
   }
   prefixes {
     prefix = var.pf_crbp_pfx02
     type   = "in" # Allowed Prefixes from Cloud
-    order  = var.pf_crbp_pfx02_order
   }
   prefixes {
     prefix = var.pf_crbp_pfx03
     type   = "in" # Allowed Prefixes from Cloud
-    order  = var.pf_crbp_pfx03_order
   }
 }
 
@@ -92,12 +88,10 @@ resource "packetfabric_cloud_router_bgp_session" "cr_bgp1" {
   prefixes {
     prefix = var.pf_crbp_pfx00
     type   = "out" # Allowed Prefixes to Cloud
-    order  = var.pf_crbp_pfx00_order
   }
   prefixes {
     prefix = var.pf_crbp_pfx01
     type   = "in"  # Allowed Prefixes from Cloud
-    order  = var.pf_crbp_pfx01_order
   }
 }
 
@@ -128,12 +122,10 @@ resource "packetfabric_cloud_router_bgp_session" "cr_bgp1" {
   prefixes {
     prefix = var.pf_crbp_pfx00
     type   = "out" # Allowed Prefixes to Cloud
-    order  = var.pf_crbp_pfx00_order
   }
   prefixes {
     prefix = var.pf_crbp_pfx01
     type   = "in"  # Allowed Prefixes from Cloud
-    order  = var.pf_crbp_pfx01_order
   }
 }
 ```
@@ -194,7 +186,7 @@ Optional:
 
 	Enum: `"exact"` `"orlonger"` `"longer"`
 - `med` (Number) The MED of this prefix. It is used when type = out.
-- `order` (Number) The order of this prefix against the others.
+- `order` (Number, Deprecated) The order of this prefix against the others.
 
 
 <a id="nestedblock--nat"></a>

--- a/examples/resources/packetfabric_cloud_router_bgp_session/resource.tf
+++ b/examples/resources/packetfabric_cloud_router_bgp_session/resource.tf
@@ -33,22 +33,18 @@ resource "packetfabric_cloud_router_bgp_session" "cr_bgp1" {
   prefixes {
     prefix = var.pf_crbp_pfx00
     type   = "out" # Allowed Prefixes to Cloud
-    order  = var.pf_crbp_pfx00_order
   }
   prefixes {
     prefix = var.pf_crbp_pfx01
     type   = "out" # Allowed Prefixes to Cloud
-    order  = var.pf_crbp_pfx01_order
   }
   prefixes {
     prefix = var.pf_crbp_pfx02
     type   = "in" # Allowed Prefixes from Cloud
-    order  = var.pf_crbp_pfx02_order
   }
   prefixes {
     prefix = var.pf_crbp_pfx03
     type   = "in" # Allowed Prefixes from Cloud
-    order  = var.pf_crbp_pfx03_order
   }
 }
 
@@ -73,12 +69,10 @@ resource "packetfabric_cloud_router_bgp_session" "cr_bgp1" {
   prefixes {
     prefix = var.pf_crbp_pfx00
     type   = "out" # Allowed Prefixes to Cloud
-    order  = var.pf_crbp_pfx00_order
   }
   prefixes {
     prefix = var.pf_crbp_pfx01
     type   = "in"  # Allowed Prefixes from Cloud
-    order  = var.pf_crbp_pfx01_order
   }
 }
 
@@ -109,11 +103,9 @@ resource "packetfabric_cloud_router_bgp_session" "cr_bgp1" {
   prefixes {
     prefix = var.pf_crbp_pfx00
     type   = "out" # Allowed Prefixes to Cloud
-    order  = var.pf_crbp_pfx00_order
   }
   prefixes {
     prefix = var.pf_crbp_pfx01
     type   = "in"  # Allowed Prefixes from Cloud
-    order  = var.pf_crbp_pfx01_order
   }
 }

--- a/examples/test.tf
+++ b/examples/test.tf
@@ -788,12 +788,10 @@ resource "random_pet" "name" {}
 #   prefixes {
 #     prefix = "0.0.0.0/0"
 #     type   = "out" # Allowed Prefixes to Cloud
-#     order  = 0
 #   }
 #   prefixes {
 #     prefix = "0.0.0.0/0"
 #     type   = "in" # Allowed Prefixes from Cloud
-#     order  = 0
 #   }
 # }
 # output "packetfabric_cloud_router_bgp_session_crbs_1" {
@@ -855,12 +853,10 @@ resource "random_pet" "name" {}
 #   prefixes {
 #     prefix = "0.0.0.0/0"
 #     type   = "out" # Allowed Prefixes to Cloud
-#     order  = 0
 #   }
 #   prefixes {
 #     prefix = "0.0.0.0/0"
 #     type   = "in" # Allowed Prefixes from Cloud
-#     order  = 0
 #   }
 # }
 # output "packetfabric_cloud_router_bgp_session_crbs_3" {

--- a/examples/use-cases/cloud_router_aws/cloud_router_connections.tf
+++ b/examples/use-cases/cloud_router_aws/cloud_router_connections.tf
@@ -91,12 +91,10 @@ resource "packetfabric_cloud_router_bgp_session" "crbs_1" {
   prefixes {
     prefix = var.aws_vpc_cidr2
     type   = "out" # Allowed Prefixes to Cloud
-    order  = 0
   }
   prefixes {
     prefix = var.aws_vpc_cidr1
     type   = "in" # Allowed Prefixes from Cloud
-    order  = 0
   }
 }
 output "packetfabric_cloud_router_bgp_session_crbs_1" {
@@ -117,12 +115,10 @@ resource "packetfabric_cloud_router_bgp_session" "crbs_2" {
   prefixes {
     prefix = var.aws_vpc_cidr1
     type   = "out" # Allowed Prefixes to Cloud
-    order  = 0
   }
   prefixes {
     prefix = var.aws_vpc_cidr2
     type   = "in" # Allowed Prefixes from Cloud
-    order  = 0
   }
 }
 output "packetfabric_cloud_router_bgp_session_crbs_2" {

--- a/examples/use-cases/cloud_router_aws_google/cloud_router_connection_aws.tf
+++ b/examples/use-cases/cloud_router_aws_google/cloud_router_connection_aws.tf
@@ -61,12 +61,10 @@ resource "packetfabric_cloud_router_bgp_session" "crbs_1" {
   prefixes {
     prefix = var.gcp_subnet_cidr1
     type   = "out" # Allowed Prefixes to Cloud
-    order  = 0
   }
   prefixes {
     prefix = var.aws_vpc_cidr1
     type   = "in" # Allowed Prefixes from Cloud
-    order  = 0
   }
 }
 output "packetfabric_cloud_router_bgp_session_crbs_1" {

--- a/examples/use-cases/cloud_router_aws_google/cloud_router_connection_google.tf
+++ b/examples/use-cases/cloud_router_aws_google/cloud_router_connection_google.tf
@@ -123,12 +123,10 @@ resource "packetfabric_cloud_router_bgp_session" "crbs_2" {
   prefixes {
     prefix = var.aws_vpc_cidr1
     type   = "out" # Allowed Prefixes to Cloud
-    order  = 0
   }
   prefixes {
     prefix = var.gcp_subnet_cidr1
     type   = "in" # Allowed Prefixes from Cloud
-    order  = 0
   }
 
   # # workaround until we can use lifecycle into Terraform gcloud Module

--- a/examples/use-cases/cloud_router_google_azure/cloud_router_connection_azure.tf
+++ b/examples/use-cases/cloud_router_google_azure/cloud_router_connection_azure.tf
@@ -82,12 +82,10 @@ resource "packetfabric_cloud_router_bgp_session" "crbs_2" {
   prefixes {
     prefix = var.gcp_subnet_cidr1
     type   = "out" # Allowed Prefixes to Cloud
-    order  = 0
   }
   prefixes {
     prefix = var.azure_vnet_cidr1
     type   = "in" # Allowed Prefixes from Cloud
-    order  = 0
   }
 }
 output "packetfabric_cloud_router_bgp_session_crbs_2" {

--- a/examples/use-cases/cloud_router_google_azure/cloud_router_connection_google.tf
+++ b/examples/use-cases/cloud_router_google_azure/cloud_router_connection_google.tf
@@ -123,12 +123,10 @@ resource "packetfabric_cloud_router_bgp_session" "crbs_1" {
   prefixes {
     prefix = var.azure_vnet_cidr1
     type   = "out" # Allowed Prefixes to Cloud
-    order  = 0
   }
   prefixes {
     prefix = var.gcp_subnet_cidr1
     type   = "in" # Allowed Prefixes from Cloud
-    order  = 0
   }
 
   # # workaround until we can use lifecycle into Terraform gcloud Module

--- a/examples/use-cases/cloud_router_google_ipsec/cloud_router_connection_google.tf
+++ b/examples/use-cases/cloud_router_google_ipsec/cloud_router_connection_google.tf
@@ -127,12 +127,10 @@ resource "packetfabric_cloud_router_bgp_session" "crbs_1" {
   prefixes {
     prefix = var.ipsec_subnet_cidr2
     type   = "out" # Allowed Prefixes to Cloud
-    order  = 0
   }
   prefixes {
     prefix = var.google_subnet_cidr1
     type   = "in" # Allowed Prefixes from Cloud
-    order  = 0
   }
 
   # # workaround until we can use lifecycle into Terraform gcloud Module

--- a/examples/use-cases/cloud_router_google_ipsec/cloud_router_connection_ipsec.tf
+++ b/examples/use-cases/cloud_router_google_ipsec/cloud_router_connection_ipsec.tf
@@ -31,12 +31,10 @@ resource "packetfabric_cloud_router_bgp_session" "crbs_2" {
   prefixes {
     prefix = var.google_subnet_cidr1
     type   = "out" # Allowed Prefixes to Cloud
-    order  = 0
   }
   prefixes {
     prefix = var.ipsec_subnet_cidr2
     type   = "in" # Allowed Prefixes from Cloud
-    order  = 0
   }
 }
 output "packetfabric_cloud_router_bgp_session_crbs_2" {

--- a/examples/use-cases/cloud_router_ibm_oracle/cloud_router_connection_ibm.tf
+++ b/examples/use-cases/cloud_router_ibm_oracle/cloud_router_connection_ibm.tf
@@ -37,12 +37,10 @@ resource "packetfabric_cloud_router_bgp_session" "crbs_1" {
   prefixes {
     prefix = var.oracle_subnet_cidr1
     type   = "out" # Allowed Prefixes to Cloud
-    order  = 0
   }
   prefixes {
     prefix = var.ibm_vpc_cidr1
     type   = "in" # Allowed Prefixes from Cloud
-    order  = 0
   }
 }
 output "packetfabric_cloud_router_bgp_session_crbs_1" {

--- a/examples/use-cases/cloud_router_ibm_oracle/cloud_router_connection_oracle.tf
+++ b/examples/use-cases/cloud_router_ibm_oracle/cloud_router_connection_oracle.tf
@@ -76,12 +76,10 @@ resource "packetfabric_cloud_router_bgp_session" "crbs_2" {
   prefixes {
     prefix = var.ibm_vpc_cidr1
     type   = "out" # Allowed Prefixes to Cloud
-    order  = 0
   }
   prefixes {
     prefix = var.oracle_subnet_cidr1
     type   = "in" # Allowed Prefixes from Cloud
-    order  = 0
   }
 }
 output "packetfabric_cloud_router_bgp_session_crbs_2" {

--- a/examples/use-cases/cloud_router_module/modules/packetfabric/cloud_router.tf
+++ b/examples/use-cases/cloud_router_module/modules/packetfabric/cloud_router.tf
@@ -75,7 +75,6 @@ resource "packetfabric_cloud_router_bgp_session" "aws" {
       prefix     = prefixes.value.prefix
       type       = "in"
       match_type = prefixes.value.match_type
-      order      = prefixes.key
     }
   }
 
@@ -85,7 +84,6 @@ resource "packetfabric_cloud_router_bgp_session" "aws" {
       prefix     = prefixes.value.prefix
       type       = "out"
       match_type = prefixes.value.match_type
-      order      = prefixes.key
     }
   }
 }
@@ -110,7 +108,6 @@ resource "packetfabric_cloud_router_bgp_session" "gcp" {
       prefix     = prefixes.value.prefix
       type       = "in"
       match_type = prefixes.value.match_type
-      order      = prefixes.key
     }
   }
 
@@ -121,7 +118,6 @@ resource "packetfabric_cloud_router_bgp_session" "gcp" {
       type       = "out"
       match_type = prefixes.value.match_type
       med        = lookup(prefixes.value, "med", 0)
-      order      = prefixes.key
     }
   }
 }

--- a/internal/packetfabric/bgp_session_test.go
+++ b/internal/packetfabric/bgp_session_test.go
@@ -45,13 +45,11 @@ func init() {
 				Prefix: _bgpPrefixOut,
 				Type:   "out",
 				Med:    2,
-				Order:  1,
 			},
 			{
 				Prefix:          _bgpPrefixIn,
 				Type:            "in",
 				LocalPreference: 100,
-				Order:           1,
 			},
 		},
 	})
@@ -92,14 +90,12 @@ func _buildBgpSessionPayload() []byte {
 			{
 				"prefix": "%s",
 				"type": "out",
-				"med": 2,
-				"order": 1
+				"med": 2
 			},
 			{
 				"prefix": "%s",
 				"type": "in",
-				"local_preference": 100,
-				"order": 1
+				"local_preference": 100
 			}
 		]
 	}`, _bgpMd5, _bgpL3Prefix, _bgpRemoteAddress, _bgpRemoteAsn, _bgpPrefixOut, _bgpPrefixIn))
@@ -127,14 +123,12 @@ func _buildBgpSessionCreateResp() []byte {
 			{
 				"prefix": "%s",
 				"type": "out",
-				"med": 2,
-				"order": 1
+				"med": 2
 			},
 			{
 				"prefix": "%s",
 				"type": "in",
-				"local_preference": 100,
-				"order": 1
+				"local_preference": 100
 			}
 		],
 		"subnet": null,
@@ -165,14 +159,12 @@ func _buildBgpSessionSettings(timeCreated, timeUpdated, bgpSettingsUUID string) 
 			{
 				"prefix": "%s",
 				"type": "out",
-				"med": 2,
-				"order": 1
+				"med": 2
 			},
 			{
 				"prefix": "%s",
 				"type": "in",
-				"local_preference": 100,
-				"order": 1
+				"local_preference": 100
 			}
 		  ]
 		}

--- a/internal/provider/datasource_bgp_session.go
+++ b/internal/provider/datasource_bgp_session.go
@@ -245,6 +245,7 @@ func dataSourceBgpSession() *schema.Resource {
 										Computed:    true,
 										Optional:    true,
 										Description: "The order of the bgp prefix against the others.",
+										Deprecated:  "This field is deprecated and will be removed in a future release.",
 									},
 								},
 							},

--- a/internal/provider/resource_bgp_session.go
+++ b/internal/provider/resource_bgp_session.go
@@ -220,6 +220,7 @@ func resourceBgpSession() *schema.Resource {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "The order of this prefix against the others.",
+							Deprecated:  "This field is deprecated and will be removed in a future release.",
 						},
 					},
 				},


### PR DESCRIPTION
## Description

[Deprecate](https://developer.hashicorp.com/terraform/plugin/sdkv2/best-practices/deprecations#provider-attribute-removal) order in packetfabric_cloud_router_bgp_session resource and data-source

## Cross-reference

PSE-10817

## Checklist

- [x] tested locally
- [x] added/updated acceptance tests
- [x] added/updated examples (in example folder)
- [x] added/updated docs
