### PR TITLE
Update default tf version to 1.1.0 in all examples

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
   }
 }

--- a/examples/test.tf
+++ b/examples/test.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
   }
 }

--- a/examples/use-cases/backbone_virtual_circuit/main.tf
+++ b/examples/use-cases/backbone_virtual_circuit/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
   }
 }

--- a/examples/use-cases/backbone_virtual_circuit_mesh/main.tf
+++ b/examples/use-cases/backbone_virtual_circuit_mesh/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
   }
 }

--- a/examples/use-cases/cloud_router_aws/provider.tf
+++ b/examples/use-cases/cloud_router_aws/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/use-cases/cloud_router_aws_google/provider.tf
+++ b/examples/use-cases/cloud_router_aws_google/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/use-cases/cloud_router_google_azure/provider.tf
+++ b/examples/use-cases/cloud_router_google_azure/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/use-cases/cloud_router_google_ipsec/provider.tf
+++ b/examples/use-cases/cloud_router_google_ipsec/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/use-cases/cloud_router_ibm_oracle/provider.tf
+++ b/examples/use-cases/cloud_router_ibm_oracle/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
     ibm = {
       source  = "IBM-Cloud/ibm"

--- a/examples/use-cases/cloud_router_module/main.tf
+++ b/examples/use-cases/cloud_router_module/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
   }
 }

--- a/examples/use-cases/cloud_router_module/modules/packetfabric/cloud_router.tf
+++ b/examples/use-cases/cloud_router_module/modules/packetfabric/cloud_router.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
   }
 }

--- a/examples/use-cases/dedicated_cloud_aws/main.tf
+++ b/examples/use-cases/dedicated_cloud_aws/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/use-cases/flex_bandwidth/main.tf
+++ b/examples/use-cases/flex_bandwidth/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
   }
 }

--- a/examples/use-cases/hosted_cloud_aws/main.tf
+++ b/examples/use-cases/hosted_cloud_aws/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/use-cases/hosted_cloud_azure/main.tf
+++ b/examples/use-cases/hosted_cloud_azure/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/use-cases/hosted_cloud_google/main.tf
+++ b/examples/use-cases/hosted_cloud_google/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
     google = {
       source  = "hashicorp/google"

--- a/examples/use-cases/marketplace/a_side/main.tf
+++ b/examples/use-cases/marketplace/a_side/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
   }
 }

--- a/examples/use-cases/marketplace/z_side/main.tf
+++ b/examples/use-cases/marketplace/z_side/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     packetfabric = {
       source  = "PacketFabric/packetfabric"
-      version = ">= 1.0.4"
+      version = ">= 1.1.0"
     }
   }
 }


### PR DESCRIPTION
## Description

Update default tf version to 1.1.0 in all examples. To be merge right before the release on March 2nd

## Checklist

- [x] added/updated examples (in example folder)
- [x] added/updated docs
