### PR TITLE
Update untagged, fix warning and cleanup

### DIFF
--- a/docs/resources/packetfabric_backbone_virtual_circuit.md
+++ b/docs/resources/packetfabric_backbone_virtual_circuit.md
@@ -10,6 +10,8 @@ description: |-
 
 A virtual circuit between two ports in the PacketFabric network. For more information, see [the PacketFabric documentation on virtual circuits](https://docs.packetfabric.com/vc/).
 
+!> **Warning:** Check the [rules](https://docs.packetfabric.com/reference/vlan_tagging/) with regards to tagging.
+
 ## Example Usage
 
 ```terraform

--- a/internal/packetfabric/cloud_service_aws.go
+++ b/internal/packetfabric/cloud_service_aws.go
@@ -88,7 +88,7 @@ type Interfaces struct {
 	Description        string `json:"description,omitempty"`
 	Vlan               int    `json:"vlan,omitempty"`
 	Svlan              int    `json:"svlan,omitempty"`
-	Untagged           bool   `json:"untagged,omitempty"`
+	Untagged           bool   `json:"untagged"`
 	ProvisioningStatus string `json:"provisioning_status,omitempty"`
 	AdminStatus        string `json:"admin_status,omitempty"`
 	OperationalStatus  string `json:"operational_status,omitempty"`

--- a/internal/packetfabric/services.go
+++ b/internal/packetfabric/services.go
@@ -21,19 +21,13 @@ const acceptCloudRouterServiceURI = "/v2/services/cloud-routers/requests/%s/acce
 const rejectCloudRouterService = "/v2/services/cloud-routers/requests/%s/reject"
 
 type Backbone struct {
-	Description     string              `json:"description"`
-	Bandwidth       Bandwidth           `json:"bandwidth"`
-	Interfaces      []BackBoneInterface `json:"interfaces"`
-	RateLimitIn     int                 `json:"rate_limit_in,omitempty"`
-	RateLimitOut    int                 `json:"rate_limit_out,omitempty"`
-	Epl             bool                `json:"epl"`
-	FlexBandwidthID string              `json:"flex_bandwidth_id,omitempty"`
-}
-
-type BackBoneInterface struct {
-	PortCircuitID string `json:"port_circuit_id"`
-	Vlan          int    `json:"vlan,omitempty"`
-	Untagged      bool   `json:"untagged,omitempty"`
+	Description     string       `json:"description"`
+	Bandwidth       Bandwidth    `json:"bandwidth"`
+	Interfaces      []Interfaces `json:"interfaces"`
+	RateLimitIn     int          `json:"rate_limit_in,omitempty"`
+	RateLimitOut    int          `json:"rate_limit_out,omitempty"`
+	Epl             bool         `json:"epl"`
+	FlexBandwidthID string       `json:"flex_bandwidth_id,omitempty"`
 }
 
 type IxVirtualCircuit struct {

--- a/internal/provider/resource_backbone.go
+++ b/internal/provider/resource_backbone.go
@@ -87,7 +87,6 @@ func resourceBackbone() *schema.Resource {
 						"untagged": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							ForceNew:    true,
 							Default:     false,
 							Description: "Whether the interface should be untagged. ",
 						},
@@ -117,7 +116,6 @@ func resourceBackbone() *schema.Resource {
 						"untagged": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							ForceNew:    true,
 							Default:     false,
 							Description: "Whether the interface should be untagged. ",
 						},

--- a/internal/provider/resource_ix_vc.go
+++ b/internal/provider/resource_ix_vc.go
@@ -80,7 +80,7 @@ func resourceIxVC() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice(ixVcSpeedOptions(), true),
+							ValidateFunc: validation.StringInSlice(speedOptions(), true),
 							Description:  "The desired speed of the new connection. Only applicable if `longhaul_type` is \"dedicated\" or \"hourly\".\n\n\tEnum: [\"50Mbps\" \"100Mbps\" \"200Mbps\" \"300Mbps\" \"400Mbps\" \"500Mbps\" \"1Gbps\" \"2Gbps\" \"5Gbps\" \"10Gbps\" \"20Gbps\" \"30Gbps\" \"40Gbps\" \"50Gbps\" \"60Gbps\" \"80Gbps\" \"100Gbps\"]",
 						},
 						"subscription_term": {
@@ -184,36 +184,10 @@ func extractIXVC(d *schema.ResourceData) packetfabric.IxVirtualCircuit {
 		ixVC.Bandwidth = extractBandwidth(bw.(map[string]interface{}))
 	}
 	for _, interf := range d.Get("interface").(*schema.Set).List() {
-		ixVC.Interface = extractIXVcInterface(interf.(map[string]interface{}))
+		ixVC.Interface = extractBackboneInterface(interf.(map[string]interface{}))
 	}
 	if flexBandID, ok := d.GetOk("flex_bandwidth_id"); ok {
 		ixVC.FlexBandwidthID = flexBandID.(string)
 	}
 	return ixVC
-}
-
-func extractIXVcInterface(interf map[string]interface{}) packetfabric.Interfaces {
-	vxInterf := packetfabric.Interfaces{}
-	if portCID := interf["port_circuit_id"]; portCID != nil {
-		vxInterf.PortCircuitID = portCID.(string)
-	}
-	if vlan := interf["vlan"]; vlan != nil {
-		vxInterf.Vlan = vlan.(int)
-	}
-	if untagged := interf["untagged"]; untagged != nil {
-		vxInterf.Untagged = untagged.(bool)
-	}
-	if svlan := interf["svlan"]; svlan != nil {
-		vxInterf.Svlan = svlan.(int)
-	}
-	return vxInterf
-}
-
-func ixVcSpeedOptions() []string {
-	return []string{
-		"50Mbps", "100Mbps", "200Mbps", "300Mbps",
-		"400Mbps", "500Mbps", "1Gbps", "2Gbps",
-		"5Gbps", "10Gbps", "20Gbps", "30Gbps",
-		"40Gbps", "50Gbps", "60Gbps", "80Gbps",
-		"100Gbps"}
 }

--- a/internal/provider/resource_third_party_virtual_circuit.go
+++ b/internal/provider/resource_third_party_virtual_circuit.go
@@ -78,7 +78,7 @@ func resourceThirdPartyVirtualCircuit() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice(ixVcSpeedOptions(), true),
+							ValidateFunc: validation.StringInSlice(speedOptions(), true),
 							Description:  "The desired speed of the new connection. Only applicable if `longhaul_type` is \"dedicated\" or \"hourly\".\n\n\tEnum: [\"50Mbps\" \"100Mbps\" \"200Mbps\" \"300Mbps\" \"400Mbps\" \"500Mbps\" \"1Gbps\" \"2Gbps\" \"5Gbps\" \"10Gbps\" \"20Gbps\" \"30Gbps\" \"40Gbps\" \"50Gbps\" \"60Gbps\" \"80Gbps\" \"100Gbps\"]",
 						},
 						"subscription_term": {

--- a/templates/resources/backbone_virtual_circuit.md.tmpl
+++ b/templates/resources/backbone_virtual_circuit.md.tmpl
@@ -10,6 +10,8 @@ description: |-
 
 A virtual circuit between two ports in the PacketFabric network. For more information, see [the PacketFabric documentation on virtual circuits](https://docs.packetfabric.com/vc/).
 
+!> **Warning:** Check the [rules](https://docs.packetfabric.com/reference/vlan_tagging/) with regards to tagging.
+
 ## Example Usage
 
 {{tffile "examples/resources/packetfabric_backbone_virtual_circuit/resource.tf"}}


### PR DESCRIPTION
## Description

- Remove `omitempty` in schema for `untagged` in `packetfabric_backbone_virtual_circuit`
- Fix following warning: 
  .flex_bandwidth_id: planned value cty.StringVal("") for a non-computed attribute
- Cleanup redundant functions `extractIXVcInterface()` = `extractBackboneInterface()` and `ixVcSpeedOptions` = `speedOptions()`
- Add link about VLAN tagging rules in the docs for backbone VC

## Checklist

- [x] tested locally
- [x] added/updated docs
