### PR TITLE
Fix autoneg and add port status in packetfabric_port

### DIFF
--- a/docs/resources/packetfabric_link_aggregation_group.md
+++ b/docs/resources/packetfabric_link_aggregation_group.md
@@ -87,6 +87,9 @@ Optional:
 - `read` (String)
 - `update` (String)
 
+
+
+
 ## Import
 
 Import a LAG using its circuit ID. 

--- a/docs/resources/packetfabric_port.md
+++ b/docs/resources/packetfabric_port.md
@@ -60,7 +60,7 @@ output "packetfabric_port_1_details" {
 
 ### Optional
 
-- `autoneg` (Boolean) Only applicable to 1Gbps ports. Controls whether auto negotiation is on (true) or off (false). The request will fail if specified with 10Gbps. Defaults: false
+- `autoneg` (Boolean) Only applicable to 1Gbps ports. Controls whether auto negotiation is on (true) or off (false). The request will fail if specified with 10Gbps.
 - `enabled` (Boolean) Change Port Admin Status. Set it to true when port is enabled, false when port is disabled. Defaults: true
 - `nni` (Boolean) Set this to true to provision an ENNI port. ENNI ports will use a nni_svlan_tpid value of 0x8100.
 

--- a/internal/provider/resource_port.go
+++ b/internal/provider/resource_port.go
@@ -39,7 +39,6 @@ func resourceInterfaces() *schema.Resource {
 			"autoneg": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
 				Description: "Only applicable to 1Gbps ports. Controls whether auto negotiation is on (true) or off (false). The request will fail if specified with 10Gbps. ",
 			},
 			"description": {


### PR DESCRIPTION
## Description

- Remove `omitempty` in schema for `autoneg` in `packetfabric_port` (same problem as #364)
- Add port status check for update operations
- Remove `default: false` to the schema for `autoneg` as it is only for 1GBps port

## Checklist

- [x] tested locally
- [x] added/updated docs
