### PR TITLE
Add PO Number to resources

### DIFF
--- a/docs/resources/packetfabric_backbone_virtual_circuit.md
+++ b/docs/resources/packetfabric_backbone_virtual_circuit.md
@@ -83,6 +83,7 @@ resource "packetfabric_backbone_virtual_circuit" "vc1" {
 
 	Defaults: false
 - `flex_bandwidth_id` (String) ID of the flex bandwidth container from which to subtract this VC's speed.
+- `po_number` (String) Purchase order number or identifier of a service.
 - `rate_limit_in` (Number) The upper bound, in Mbps, by which to limit incoming data.
 - `rate_limit_out` (Number) The upper bound, in Mbps, by which to limit outgoing data.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/docs/resources/packetfabric_cloud_router.md
+++ b/docs/resources/packetfabric_cloud_router.md
@@ -47,6 +47,7 @@ output "packetfabric_cloud_router" {
 - `asn` (Number) The ASN of the cloud router.
 
 	This can be the PacketFabric public ASN 4556 (default) or a private ASN from 64512 - 65534. Defaults: 4556
+- `po_number` (String) Purchase order number or identifier of a service.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/packetfabric_cloud_router_connection_aws.md
+++ b/docs/resources/packetfabric_cloud_router_connection_aws.md
@@ -95,6 +95,7 @@ resource "aws_dx_connection_confirmation" "confirmation" {
 - `is_public` (Boolean) Whether PacketFabric should allocate a public IP address for this connection. Set this to true if you intend to use a public VIF on the AWS side. Defaults: false
 - `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection. Defaults: false
 - `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection. Defaults: false
+- `po_number` (String) Purchase order number or identifier of a service.
 - `published_quote_line_uuid` (String) UUID of the published quote line which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The desired AWS availability zone of the new connection.

--- a/docs/resources/packetfabric_cloud_router_connection_azure.md
+++ b/docs/resources/packetfabric_cloud_router_connection_azure.md
@@ -72,6 +72,7 @@ output "packetfabric_cloud_router_connection_azure" {
 - `is_public` (Boolean) Whether PacketFabric should allocate a public IP address for this connection. Set this to true if you intend to set up peering with Microsoft public services (such as Microsoft 365). Defaults: false
 - `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection. Defaults: false
 - `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection. Defaults: false
+- `po_number` (String) Purchase order number or identifier of a service.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/docs/resources/packetfabric_cloud_router_connection_google.md
+++ b/docs/resources/packetfabric_cloud_router_connection_google.md
@@ -67,6 +67,7 @@ output "packetfabric_cloud_router_connection_google" {
 
 - `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection. Defaults: false
 - `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection. Defaults: false
+- `po_number` (String) Purchase order number or identifier of a service.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/docs/resources/packetfabric_cloud_router_connection_ibm.md
+++ b/docs/resources/packetfabric_cloud_router_connection_ibm.md
@@ -61,6 +61,7 @@ output "packetfabric_cloud_router_connection_ibm" {
 - `ibm_bgp_ibm_cidr` (String) The IP address in CIDR format for the IBM-side router in the BGP session. If you do not specify an address, IBM will assign one on your behalf. See the documentation for information on which IP ranges are allowed.
 - `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection. Defaults: false
 - `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection. Defaults: false
+- `po_number` (String) Purchase order number or identifier of a service.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The desired availability zone of the connection.

--- a/docs/resources/packetfabric_cloud_router_connection_ipsec.md
+++ b/docs/resources/packetfabric_cloud_router_connection_ipsec.md
@@ -96,6 +96,7 @@ output "packetfabric_cloud_router_connection_ipsec" {
 - `phase2_authentication_algo` (String) The authentication algorithm to use during phase 2. It cannot be null if phase2_encryption_algo is CBC. 
 
 	Enum: "hmac-md5-96" "hmac-sha-256-128" "hmac-sha1-96"
+- `po_number` (String) Purchase order number or identifier of a service.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/docs/resources/packetfabric_cloud_router_connection_oracle.md
+++ b/docs/resources/packetfabric_cloud_router_connection_oracle.md
@@ -55,6 +55,7 @@ output "packetfabric_cloud_router_connection_oracle" {
 
 - `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection. Defaults: false
 - `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection. Defaults: false
+- `po_number` (String) Purchase order number or identifier of a service.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The desired availability zone of the new connection.

--- a/docs/resources/packetfabric_cloud_router_connection_port.md
+++ b/docs/resources/packetfabric_cloud_router_connection_port.md
@@ -56,6 +56,7 @@ output "packetfabric_cloud_router_connection_port" {
 - `is_public` (Boolean) Whether PacketFabric should allocate a public IP address for this connection. Defaults: false
 - `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection. Defaults: false
 - `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection. Defaults: false
+- `po_number` (String) Purchase order number or identifier of a service.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `untagged` (Boolean) Whether the interface should be untagged. Do not specify a VLAN if this is to be an untagged connection. Defaults: false
 - `vlan` (Number) Valid VLAN range is from 4-4094, inclusive.

--- a/docs/resources/packetfabric_cs_aws_dedicated_connection.md
+++ b/docs/resources/packetfabric_cs_aws_dedicated_connection.md
@@ -62,6 +62,7 @@ output "packetfabric_cs_aws_dedicated_connection" {
 - `loa` (String) A base64 encoded string of a PDF of the LOA that AWS provided.
 
 	Example: SSBhbSBhIFBERg==
+- `po_number` (String) Purchase order number or identifier of a service.
 - `should_create_lag` (Boolean) Create the dedicated connection as a LAG interface. Defaults: true
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The desired AWS availability zone of the new connection.

--- a/docs/resources/packetfabric_cs_aws_hosted_connection.md
+++ b/docs/resources/packetfabric_cs_aws_hosted_connection.md
@@ -64,6 +64,7 @@ output "packetfabric_cs_aws_hosted_connection" {
 
 ### Optional
 
+- `po_number` (String) Purchase order number or identifier of a service.
 - `src_svlan` (Number) Valid S-VLAN range is from 4-4094, inclusive.
 - `zone` (String) The desired zone of the new connection.
 

--- a/docs/resources/packetfabric_cs_azure_dedicated_connection.md
+++ b/docs/resources/packetfabric_cs_azure_dedicated_connection.md
@@ -57,6 +57,7 @@ output "packetfabric_cs_azure_dedicated_connection" {
 ### Optional
 
 - `loa` (String) A base64 encoded string of a PDF for the LOA that you generated from the Azure portal
+- `po_number` (String) Purchase order number or identifier of a service.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The desired zone of the new connection.

--- a/docs/resources/packetfabric_cs_azure_hosted_connection.md
+++ b/docs/resources/packetfabric_cs_azure_hosted_connection.md
@@ -62,6 +62,7 @@ output "packetfabric_cs_azure_hosted_connection" {
 
 ### Optional
 
+- `po_number` (String) Purchase order number or identifier of a service.
 - `src_svlan` (Number) Valid S-VLAN range is from 4-4094, inclusive.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `vlan_microsoft` (Number) The VLAN ID you are using for Microsoft peering. This is optional and is used to connect to Office 365.

--- a/docs/resources/packetfabric_cs_google_dedicated_connection.md
+++ b/docs/resources/packetfabric_cs_google_dedicated_connection.md
@@ -51,6 +51,7 @@ output "packetfabric_cs_google_dedicated_connection" {
 
 - `autoneg` (Boolean) Whether the port auto-negotiates or not. This is currently only possible with 1Gbps ports and the request will fail if specified with 10Gbps. Defaults: false
 - `loa` (String) A base64 encoded string of a PDF of the LOA that Google provided.
+- `po_number` (String) Purchase order number or identifier of a service.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The desired zone of the new connection.

--- a/docs/resources/packetfabric_cs_google_hosted_connection.md
+++ b/docs/resources/packetfabric_cs_google_hosted_connection.md
@@ -51,6 +51,7 @@ output "packetfabric_cs_google_hosted_connection" {
 
 ### Optional
 
+- `po_number` (String) Purchase order number or identifier of a service.
 - `src_svlan` (Number) Valid S-VLAN range is from 4-4094, inclusive.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/docs/resources/packetfabric_cs_ibm_hosted_connection.md
+++ b/docs/resources/packetfabric_cs_ibm_hosted_connection.md
@@ -49,6 +49,7 @@ output "packetfabric_cs_ibm_hosted_connection" {
 
 - `ibm_bgp_cer_cidr` (String) The IP address in CIDR format for the PacketFabric-side router in the BGP session. If you do not specify an address, IBM will assign one on your behalf.
 - `ibm_bgp_ibm_cidr` (String) The IP address in CIDR format for the IBM-side router in the BGP session. If you do not specify an address, IBM will assign one on your behalf. See the documentation for information on which IP ranges are allowed.
+- `po_number` (String) Purchase order number or identifier of a service.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `src_svlan` (Number) Valid S-VLAN range is from 4-4094, inclusive.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/docs/resources/packetfabric_cs_oracle_hosted_connection.md
+++ b/docs/resources/packetfabric_cs_oracle_hosted_connection.md
@@ -47,6 +47,7 @@ output "packetfabric_cs_oracle_hosted_connection" {
 
 ### Optional
 
+- `po_number` (String) Purchase order number or identifier of a service.
 - `published_quote_line_uuid` (String) UUID of the published quote line with this connection should be associated.
 - `src_svlan` (Number) Valid S-VLAN range is from 4-4094, inclusive.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/docs/resources/packetfabric_link_aggregation_group.md
+++ b/docs/resources/packetfabric_link_aggregation_group.md
@@ -71,6 +71,7 @@ output "packetfabric_link_aggregation_group" {
 
 ### Optional
 
+- `po_number` (String) Purchase order number or identifier of a service.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/packetfabric_point_to_point.md
+++ b/docs/resources/packetfabric_point_to_point.md
@@ -52,6 +52,7 @@ resource "packetfabric_point_to_point" "ptp1" {
 
 ### Optional
 
+- `po_number` (String) Purchase order number or identifier of a service.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/docs/resources/packetfabric_port.md
+++ b/docs/resources/packetfabric_port.md
@@ -65,6 +65,7 @@ output "packetfabric_port_1_details" {
 - `nni` (Boolean) Set this to true to provision an ENNI port. ENNI ports will use a nni_svlan_tpid value of 0x8100.
 
 	By default, ENNI ports are not available to all users. If you are provisioning your first ENNI port and are unsure if you have permission, contact support@packetfabric.com. Defaults: false
+- `po_number` (String) Purchase order number or identifier of a service.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) Availability zone of the port.
 

--- a/internal/packetfabric/cloud_router.go
+++ b/internal/packetfabric/cloud_router.go
@@ -17,6 +17,7 @@ type CloudRouter struct {
 	AccountUUID string   `json:"account_uuid"`
 	Regions     []string `json:"regions,omitempty"`
 	Capacity    string   `json:"capacity"`
+	PONumber    string   `json:"po_number,omitempty"`
 }
 
 // This struct represents a Cloud Router create response

--- a/internal/packetfabric/cloud_router.go
+++ b/internal/packetfabric/cloud_router.go
@@ -30,6 +30,7 @@ type CloudRouterResponse struct {
 	Regions     []Region `json:"regions"`
 	TimeCreated string   `json:"time_created"`
 	TimeUpdated string   `json:"time_updated"`
+	PONumber    string   `json:"po_number"`
 }
 
 // This struct represents a Cloud Router Region

--- a/internal/packetfabric/cloud_router_connection.go
+++ b/internal/packetfabric/cloud_router_connection.go
@@ -26,6 +26,7 @@ type AwsConnection struct {
 	IsPublic               bool   `json:"is_public,omitempty"`
 	Speed                  string `json:"speed,omitempty"`
 	PublishedQuoteLineUUID string `json:"published_quote_line_uuid,omitempty"`
+	PONumber               string `json:"po_number,omitempty"`
 }
 
 type AwsConnectionCreateResponse struct {
@@ -183,6 +184,7 @@ type IBMCloudRouterConn struct {
 	Zone                   string `json:"zone,omitempty"`
 	Speed                  string `json:"speed,omitempty"`
 	PublishedQuoteLineUUID string `json:"published_quote_line_uuid,omitempty"`
+	PONumber               string `json:"po_number,omitempty"`
 }
 
 type IPSecRouterConn struct {
@@ -203,6 +205,7 @@ type IPSecRouterConn struct {
 	GatewayAddress             string `json:"gateway_address,omitempty"`
 	SharedKey                  string `json:"shared_key,omitempty"`
 	PublishedQuoteLineUUID     string `json:"published_quote_line_uuid,omitempty"`
+	PONumber                   string `json:"po_number,omitempty"`
 }
 
 type OracleCloudRouterConn struct {
@@ -215,6 +218,7 @@ type OracleCloudRouterConn struct {
 	Pop                    string `json:"pop,omitempty"`
 	Zone                   string `json:"zone,omitempty"`
 	PublishedQuoteLineUUID string `json:"published_quote_line_uuid,omitempty"`
+	PONumber               string `json:"po_number,omitempty"`
 }
 
 type IPSecConnUpdate struct {

--- a/internal/packetfabric/cloud_router_connection.go
+++ b/internal/packetfabric/cloud_router_connection.go
@@ -80,6 +80,7 @@ type CloudRouterConnectionReadResponse struct {
 	Zone                      string        `json:"zone,omitempty"`
 	Vlan                      int           `json:"vlan,omitempty"`
 	DesiredNat                string        `json:"desired_nat,omitempty"`
+	PONumber                  string        `json:"po_number"`
 }
 
 type BgpStateObj struct {
@@ -160,8 +161,9 @@ type AwsComponents struct {
 	IfdPortCircuitIDPf   string `json:"ifd_port_circuit_id_pf"`
 }
 
-type DescriptionUpdate struct {
+type CloudRouterUpdateData struct {
 	Description string `json:"description"`
+	PONumber    string `json:"po_number"`
 }
 
 type ConnectionDeleteResp struct {
@@ -329,11 +331,11 @@ func (c *PFClient) ReadCloudRouterConnection(cID, connCid string) (*CloudRouterC
 	return resp, nil
 }
 
-func (c *PFClient) UpdateCloudRouterConnection(cID, connCid string, description DescriptionUpdate) (*CloudRouterConnectionReadResponse, error) {
+func (c *PFClient) UpdateCloudRouterConnection(cID, connCid string, cloudRouterUpdateData CloudRouterUpdateData) (*CloudRouterConnectionReadResponse, error) {
 	formatedURI := fmt.Sprintf(cloudRouterConnectionByCidURI, cID, connCid)
 
 	resp := &CloudRouterConnectionReadResponse{}
-	_, err := c.sendRequest(formatedURI, patchMethod, description, resp)
+	_, err := c.sendRequest(formatedURI, patchMethod, cloudRouterUpdateData, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/packetfabric/cloud_router_connection_test.go
+++ b/internal/packetfabric/cloud_router_connection_test.go
@@ -250,7 +250,7 @@ func _buildMockCloudRouterConnResp(cloudRouterConnUpdateData CloudRouterUpdateDa
 		"dnat_capable": false,
 		"zone": "A",
 		"vlan": 4,
-		"desired_nat": "overload"
+		"desired_nat": "overload",
 		"po_number": "%s"
 	  }`, cloudRouterConnUpdateData.Description, _cloudConnUUID, cloudRouterConnUpdateData.PONumber))
 }

--- a/internal/packetfabric/cloud_router_connection_test.go
+++ b/internal/packetfabric/cloud_router_connection_test.go
@@ -11,6 +11,7 @@ const _cloudCircuitID = "PF-AP-LAX1-1002"
 const _cloudConnCid = "PF-CC-LAX-NYC-0192345"
 const _cloudConnDesc = "New Super Cool Cloud Router Connection"
 const _cloudConnUpdateDesc = "Updated Cloud Router Connection"
+const _cloudConnUpdatePONumber = "Updated Cloud Router Connection PO Number"
 const _cloudConnUUID = "095be615-a8ad-4c33-8e9c-c7612fbf6c9f"
 const _cloudConnCustomerUUID = "e7eefd45-cb13-4c62-b229-e5bbc1362123"
 const _cloudConnUserUUID = "7c4d2d7d-8620-4fb3-967a-4a621082cf1f"
@@ -93,13 +94,14 @@ func Test_ReadCloudRouterConnection(t *testing.T) {
 
 func Test_UpdateCloudRouterConnection(t *testing.T) {
 	var expectedResp CloudRouterConnectionReadResponse
-	payload := DescriptionUpdate{
+	payload := CloudRouterUpdateData{
 		Description: _cloudConnUpdateDesc,
+		PONumber:    _cloudConnUpdatePONumber,
 	}
-	if err := json.Unmarshal(_buildMockCloudRouterConnResp(_cloudConnUpdateDesc), &expectedResp); err != nil {
+	if err := json.Unmarshal(_buildMockCloudRouterConnResp(payload), &expectedResp); err != nil {
 		t.Fatalf("Failed to unmarshal CloudRouterConnectionReadResponse: %s", err)
 	}
-	cTest.runFakeHttpServer(_callUpdateAwsConn, payload, expectedResp, _buildMockCloudRouterConnResp(_cloudConnUpdateDesc), "aws-cloud-router-conn-update", t)
+	cTest.runFakeHttpServer(_callUpdateAwsConn, payload, expectedResp, _buildMockCloudRouterConnResp(payload), "aws-cloud-router-conn-update", t)
 }
 
 func Test_GetCloudConnectionStatus(t *testing.T) {
@@ -143,7 +145,7 @@ func _callListAwsRouterConnections(payload interface{}) (interface{}, error) {
 }
 
 func _callUpdateAwsConn(payload interface{}) (interface{}, error) {
-	return cTest.UpdateCloudRouterConnection(_circuitIdMock, _cloudConnCid, payload.(DescriptionUpdate))
+	return cTest.UpdateCloudRouterConnection(_circuitIdMock, _cloudConnCid, payload.(CloudRouterUpdateData))
 }
 
 func _callDeleteAwsConn(payload interface{}) (interface{}, error) {
@@ -201,7 +203,7 @@ func _buildMockCloudRouterCreateResp() []byte {
 	}`, _customerUUID, _userUUID, _cloudCircuitID, _accountUUID, _awsAccountID, _accountUUID))
 }
 
-func _buildMockCloudRouterConnResp(description string) []byte {
+func _buildMockCloudRouterConnResp(cloudRouterConnUpdateData CloudRouterUpdateData) []byte {
 	return []byte(fmt.Sprintf(`{
 		"port_type": "hosted",
 		"connection_type": "cloud_hosted",
@@ -249,7 +251,8 @@ func _buildMockCloudRouterConnResp(description string) []byte {
 		"zone": "A",
 		"vlan": 4,
 		"desired_nat": "overload"
-	  }`, description, _cloudConnUUID))
+		"po_number": "%s"
+	  }`, cloudRouterConnUpdateData.Description, _cloudConnUUID, cloudRouterConnUpdateData.PONumber))
 }
 
 func buildMockCloudRouterReadResp(description string) []byte {

--- a/internal/packetfabric/cloud_router_port.go
+++ b/internal/packetfabric/cloud_router_port.go
@@ -15,6 +15,7 @@ type CustomerOwnedPort struct {
 	Speed                  string `json:"speed,omitempty"`
 	IsPublic               bool   `json:"is_public,omitempty"`
 	PublishedQuoteLineUUID string `json:"published_quote_line_uuid,omitempty"`
+	PONumber               string `json:"po_number,omitempty"`
 }
 
 type CustomerOwnedPortResp struct {

--- a/internal/packetfabric/cloud_service_aws.go
+++ b/internal/packetfabric/cloud_service_aws.go
@@ -113,6 +113,7 @@ type HostedAwsConnection struct {
 	SrcSvlan     int    `json:"src_svlan,omitempty"`
 	Zone         string `json:"zone,omitempty"`
 	Speed        string `json:"speed,omitempty"`
+	PONumber     string `json:"po_number,omitempty"`
 }
 
 type DedicatedAwsConn struct {
@@ -127,6 +128,7 @@ type DedicatedAwsConn struct {
 	Speed            string      `json:"speed"`
 	ShouldCreateLag  bool        `json:"should_create_lag"`
 	Loa              interface{} `json:"load"`
+	PONumber         string      `json:"po_number,omitempty"`
 }
 
 type CloudServiceConnCreateResp struct {

--- a/internal/packetfabric/cloud_service_aws.go
+++ b/internal/packetfabric/cloud_service_aws.go
@@ -393,20 +393,20 @@ func (c *PFClient) DeleteRequestedHostedMktService(vcRequestUUID string) error {
 	return c._deleteMktService(vcRequestUUID, hostedMktService)
 }
 
-func (c *PFClient) UpdateServiceHostedConn(description, cloudCID string) (*CloudServiceConnCreateResp, error) {
+func (c *PFClient) UpdateServiceHostedConn(cloudCID string, updateServiceConnData UpdateServiceConn) (*CloudServiceConnCreateResp, error) {
 	formatedURI := fmt.Sprintf(updateCloudConnHostedURI, cloudCID)
 	expectedResp := &CloudServiceConnCreateResp{}
-	_, err := c.sendRequest(formatedURI, patchMethod, UpdateServiceConn{description}, expectedResp)
+	_, err := c.sendRequest(formatedURI, patchMethod, updateServiceConnData, expectedResp)
 	if err != nil {
 		return nil, err
 	}
 	return expectedResp, err
 }
 
-func (c *PFClient) UpdateServiceDedicatedConn(description, cloudCID string) (*CloudServiceConnCreateResp, error) {
+func (c *PFClient) UpdateServiceDedicatedConn(cloudCID string, updateServiceConnData UpdateServiceConn) (*CloudServiceConnCreateResp, error) {
 	formatedURI := fmt.Sprintf(updateCloudConnDedicatedURI, cloudCID)
 	expectedResp := &CloudServiceConnCreateResp{}
-	_, err := c.sendRequest(formatedURI, patchMethod, UpdateServiceConn{description}, expectedResp)
+	_, err := c.sendRequest(formatedURI, patchMethod, updateServiceConnData, expectedResp)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/packetfabric/cloud_service_aws_test.go
+++ b/internal/packetfabric/cloud_service_aws_test.go
@@ -100,7 +100,7 @@ func _callCreateDedicadedAWSConn(payload interface{}) (interface{}, error) {
 }
 
 func _callUpdateAwsServiceConn(payload interface{}) (interface{}, error) {
-	return cTest.UpdateServiceHostedConn(_awsServiceConnDesc, _cloudCircuitID)
+	return cTest.UpdateServiceHostedConn(_cloudCircuitID, UpdateServiceConn{Description: _awsServiceConnDesc})
 }
 
 func _callGetCloudConnInfo(payload interface{}) (interface{}, error) {

--- a/internal/packetfabric/cloud_service_azure.go
+++ b/internal/packetfabric/cloud_service_azure.go
@@ -131,6 +131,7 @@ type AzureExpressRoute struct {
 	SrcSvlan               int    `json:"src_svlan,omitempty"`
 	Speed                  string `json:"speed,omitempty"`
 	PublishedQuoteLineUUID string `json:"published_quote_line_uuid,omitempty"`
+	PONumber               string `json:"po_number,omitempty"`
 }
 
 type AzureExpressRouteConn struct {
@@ -142,6 +143,7 @@ type AzureExpressRouteConn struct {
 	Speed                  string `json:"speed,omitempty"`
 	IsPublic               bool   `json:"is_public,omitempty"`
 	PublishedQuoteLineUUID string `json:"published_quote_line_uuid,omitempty"`
+	PONumber               string `json:"po_number,omitempty"`
 }
 
 type AzureBilling struct {
@@ -170,6 +172,7 @@ type AzureExpressRouteDedicated struct {
 	Encapsulation          string `json:"encapsulation,omitempty"`
 	PortCategory           string `json:"port_category,omitempty"`
 	PublishedQuoteLineUUID string `json:"published_quote_line_uuid,omitempty"`
+	PONumber               string `json:"po_number,omitempty"`
 }
 
 func (c *PFClient) CreateAzureHostedMktRequest(azureMktReq AzureHostedMktReq) (*AzureHostedMktReqResp, error) {

--- a/internal/packetfabric/cloud_service_google.go
+++ b/internal/packetfabric/cloud_service_google.go
@@ -30,6 +30,7 @@ type GoogleCloudRouterConn struct {
 	Pop                      string `json:"pop,omitempty"`
 	Speed                    string `json:"speed,omitempty"`
 	PublishedQuoteLineUUID   string `json:"published_quote_line_uuid,omitempty"`
+	PONumber                 string `json:"po_number,omitempty"`
 }
 
 type GoogleMktCloudConnCreateResp struct {
@@ -61,6 +62,7 @@ type GoogleReqHostedConn struct {
 	Pop                      string `json:"pop,omitempty"`
 	Speed                    string `json:"speed,omitempty"`
 	PublishedQuoteLineUUID   string `json:"published_quote_line_uuid,omitempty"`
+	PONumber                 string `json:"po_number,omitempty"`
 }
 
 // Struct representation: https://docs.packetfabric.com/api/v2/redoc/#operation/google_dedicated_connection_post
@@ -75,6 +77,7 @@ type GoogleReqDedicatedConn struct {
 	Speed                  string `json:"speed,omitempty"`
 	Loa                    string `json:"loa,omitempty"`
 	PublishedQuoteLineUUID string `json:"published_quote_line_uuid,omitempty"`
+	PONumber               string `json:"po_number,omitempty"`
 }
 
 func (c *PFClient) CreateRequestHostedGoogleMktConn(googleConn GoogleMktCloudConn) (*GoogleMktCloudConnCreateResp, error) {

--- a/internal/packetfabric/cloud_service_ibm.go
+++ b/internal/packetfabric/cloud_service_ibm.go
@@ -16,6 +16,7 @@ type HostedIBMConn struct {
 	Zone                   string `json:"zone,omitempty"`
 	Speed                  string `json:"speed,omitempty"`
 	PublishedQuoteLineUUID string `json:"published_quote_line_uuid,omitempty"`
+	PONumber               string `json:"po_number,omitempty"`
 }
 
 func (c *PFClient) CreateHostedIBMConn(conn HostedIBMConn) (*CloudServiceConnCreateResp, error) {

--- a/internal/packetfabric/cloud_service_oracle.go
+++ b/internal/packetfabric/cloud_service_oracle.go
@@ -25,6 +25,7 @@ type CloudServiceOracleConn struct {
 	Vlan                   int    `json:"vlan,omitempty"`
 	SrcSvlan               int    `json:"src_svlan,omitempty"`
 	PublishedQuoteLineUUID string `json:"published_quote_line_uuid,omitempty"`
+	PONumber               string `json:"po_number,omitempty"`
 }
 
 type CloudServiceOracleConnResp struct {

--- a/internal/packetfabric/point_to_point.go
+++ b/internal/packetfabric/point_to_point.go
@@ -36,6 +36,12 @@ type PointToPointResp struct {
 	Deleted      bool         `json:"deleted,omitempty"`
 	ServiceClass string       `json:"service_class,omitempty"`
 	Interfaces   []Interfaces `json:"interfaces,omitempty"`
+	PONumber     string       `json:"po_number"`
+}
+
+type UpdatePointToPointData struct {
+	Description string `json:"description"`
+	PONumber    string `json:"po_number"`
 }
 
 func (c *PFClient) CreatePointToPointService(ptp PointToPoint) (*PointToPointResp, error) {
@@ -103,13 +109,10 @@ func (c *PFClient) ReadPointToPoint(ptpCircuitID string) (*PointToPointResp, err
 	return expectedResp, nil
 }
 
-func (c *PFClient) UpdatePointToPoint(ptpUUID, description string) (*PointToPointResp, error) {
+func (c *PFClient) UpdatePointToPoint(ptpUUID string, updatePointToPointData UpdatePointToPointData) (*PointToPointResp, error) {
 	formatedURI := fmt.Sprintf(pointToPointByUUIDURI, ptpUUID)
 	expectedResp := &PointToPointResp{}
-	type DescUpdate struct {
-		Description string `json:"description"`
-	}
-	if _, err := c.sendRequest(formatedURI, patchMethod, &DescUpdate{Description: description}, expectedResp); err != nil {
+	if _, err := c.sendRequest(formatedURI, patchMethod, updatePointToPointData, expectedResp); err != nil {
 		return nil, err
 	}
 	return expectedResp, nil

--- a/internal/packetfabric/point_to_point.go
+++ b/internal/packetfabric/point_to_point.go
@@ -14,6 +14,7 @@ type PointToPoint struct {
 	AccountUUID            string      `json:"account_uuid,omitempty"`
 	SubscriptionTerm       int         `json:"subscription_term,omitempty"`
 	PublishedQuoteLineUUID string      `json:"published_quote_line_uuid,omitempty"`
+	PONumber               string      `json:"po_number,omitempty"`
 }
 type Endpoints struct {
 	Pop              string `json:"pop,omitempty"`

--- a/internal/packetfabric/ports.go
+++ b/internal/packetfabric/ports.go
@@ -113,6 +113,7 @@ type InterfaceReadResp struct {
 	CustomerUUID        string `json:"customer_uuid,omitempty"`
 	MaxCloudRouterSpeed string `json:"max_cloud_router_speed,omitempty"`
 	Links               Links  `json:"_links,omitempty"`
+	PONumber            string `json:"po_number"`
 }
 
 type Links struct {
@@ -197,6 +198,12 @@ type PortRouterLogs struct {
 	Severity     int    `json:"severity,omitempty"`
 	SeverityName string `json:"severity_name,omitempty"`
 	Timestamp    string `json:"timestamp,omitempty"`
+}
+
+type PortUpdate struct {
+	Autoneg     bool   `json:"autoneg"`
+	Description string `json:"description"`
+	PONumber    string `json:"po_number"`
 }
 
 func (c *PFClient) CreateInterface(interf Interface) (*InterfaceCreateResp, error) {
@@ -318,18 +325,10 @@ func (c *PFClient) GetPortRouterLogs(portCID, timeFrom, timeTo string) ([]PortRo
 	return expectedResp, nil
 }
 
-func (c *PFClient) UpdatePort(autoNeg bool, portCID, description string) (*InterfaceReadResp, error) {
+func (c *PFClient) UpdatePort(portCID string, portUpdateData PortUpdate) (*InterfaceReadResp, error) {
 	formatedURI := fmt.Sprintf(portByCIDURI, portCID)
 	expectedResp := &InterfaceReadResp{}
-	type PortUpdate struct {
-		Autoneg     bool   `json:"autoneg"`
-		Description string `json:"description"`
-	}
-	portUpdate := PortUpdate{
-		Autoneg:     autoNeg,
-		Description: description,
-	}
-	_, err := c.sendRequest(formatedURI, patchMethod, portUpdate, expectedResp)
+	_, err := c.sendRequest(formatedURI, patchMethod, portUpdateData, expectedResp)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/packetfabric/ports.go
+++ b/internal/packetfabric/ports.go
@@ -30,6 +30,7 @@ type Interface struct {
 	VlanMicrosoft    int    `json:"vlan_microsoft,omitempty"`
 	VlanPrivate      int    `json:"vlan_private,omitempty"`
 	Untagged         bool   `json:"untagged,omitempty"`
+	PONumber         string `json:"po_number,omitempty"`
 }
 
 type InterfaceCreateResp struct {

--- a/internal/packetfabric/services.go
+++ b/internal/packetfabric/services.go
@@ -47,6 +47,7 @@ type ServiceSettingsUpdate struct {
 	RateLimitOut int          `json:"rate_limit_out,omitempty"`
 	Description  string       `json:"description,omitempty"`
 	Interfaces   []Interfaces `json:"interfaces,omitempty"`
+	PONumber     string       `json:"po_number,omitempty"`
 }
 
 type BackboneResp struct {
@@ -66,6 +67,7 @@ type BackboneResp struct {
 	TimeCreated         string               `json:"time_created"`
 	TimeUpdated         string               `json:"time_updated"`
 	Interfaces          []BackboneInterfResp `json:"interfaces"`
+	PONumber            string               `json:"po_number"`
 }
 
 type BackboneInterfResp struct {

--- a/internal/packetfabric/services.go
+++ b/internal/packetfabric/services.go
@@ -28,6 +28,7 @@ type Backbone struct {
 	RateLimitOut    int          `json:"rate_limit_out,omitempty"`
 	Epl             bool         `json:"epl"`
 	FlexBandwidthID string       `json:"flex_bandwidth_id,omitempty"`
+	PONumber        string       `json:"po_number,omitempty"`
 }
 
 type IxVirtualCircuit struct {

--- a/internal/provider/resource_aws_cloud_router_connection.go
+++ b/internal/provider/resource_aws_cloud_router_connection.go
@@ -102,9 +102,10 @@ func resourceRouterConnectionAws() *schema.Resource {
 				Description:  "UUID of the published quote line which this connection should be associated.",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_aws_cloud_router_connection.go
+++ b/internal/provider/resource_aws_cloud_router_connection.go
@@ -101,6 +101,11 @@ func resourceRouterConnectionAws() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "UUID of the published quote line which this connection should be associated.",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: CloudRouterImportStatePassthroughContext,
@@ -162,6 +167,7 @@ func resourceRouterConnectionAwsRead(ctx context.Context, d *schema.ResourceData
 	_ = d.Set("pop", resp.Pop)
 	_ = d.Set("zone", resp.Zone)
 	_ = d.Set("aws_account_id", resp.CloudSettings.AwsAccountID)
+	_ = d.Set("po_number", resp.PONumber)
 
 	if resp.CloudSettings.PublicIP != "" {
 		_ = d.Set("is_public", true)

--- a/internal/provider/resource_aws_cloud_router_connection.go
+++ b/internal/provider/resource_aws_cloud_router_connection.go
@@ -198,5 +198,6 @@ func extractAwsConnection(d *schema.ResourceData) packetfabric.AwsConnection {
 		IsPublic:               d.Get("is_public").(bool),
 		Speed:                  d.Get("speed").(string),
 		PublishedQuoteLineUUID: d.Get("published_quote_line_uuid").(string),
+		PONumber:               d.Get("po_number").(string),
 	}
 }

--- a/internal/provider/resource_aws_dedicated_conn.go
+++ b/internal/provider/resource_aws_dedicated_conn.go
@@ -97,6 +97,11 @@ func resourceAwsReqDedicatedConn() *schema.Resource {
 				ForceNew:    true,
 				Description: "A base64 encoded string of a PDF of the LOA that AWS provided.\n\n\tExample: SSBhbSBhIFBERg==",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -163,6 +168,7 @@ func resourceAwsReqDedicatedConnRead(ctx context.Context, d *schema.ResourceData
 	if resp2 != nil {
 		_ = d.Set("autoneg", resp2.Autoneg)
 		_ = d.Set("zone", resp2.Zone)
+		_ = d.Set("po_number", resp2.PONumber)
 		if resp2.IsLag {
 			_ = d.Set("should_create_lag", true)
 		} else {
@@ -174,8 +180,7 @@ func resourceAwsReqDedicatedConnRead(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceAwsReqDedicatedConnUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*packetfabric.PFClient)
-	return resourceServicesDedicatedUpdate(ctx, d, m, c.UpdateServiceDedicatedConn)
+	return resourceServicesDedicatedUpdate(ctx, d, m)
 }
 
 func resourceAwsServicesDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/internal/provider/resource_aws_dedicated_conn.go
+++ b/internal/provider/resource_aws_dedicated_conn.go
@@ -200,5 +200,6 @@ func extractDedicatedConn(d *schema.ResourceData) packetfabric.DedicatedAwsConn 
 		Speed:            d.Get("speed").(string),
 		ShouldCreateLag:  d.Get("should_create_lag").(bool),
 		Loa:              d.Get("loa"),
+		PONumber:         d.Get("po_number").(string),
 	}
 }

--- a/internal/provider/resource_aws_dedicated_conn.go
+++ b/internal/provider/resource_aws_dedicated_conn.go
@@ -98,9 +98,10 @@ func resourceAwsReqDedicatedConn() *schema.Resource {
 				Description: "A base64 encoded string of a PDF of the LOA that AWS provided.\n\n\tExample: SSBhbSBhIFBERg==",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_aws_hosted_conn.go
+++ b/internal/provider/resource_aws_hosted_conn.go
@@ -85,9 +85,10 @@ func resourceAwsRequestHostConn() *schema.Resource {
 				Description:  "The speed of the new connection.\n\n\tAvailable: 50Mbps 100Mbps 200Mbps 300Mbps 400Mbps 500Mbps 1Gbps 2Gbps 5Gbps 10Gbps",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_aws_hosted_conn.go
+++ b/internal/provider/resource_aws_hosted_conn.go
@@ -84,6 +84,11 @@ func resourceAwsRequestHostConn() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(speedOptions(), true),
 				Description:  "The speed of the new connection.\n\n\tAvailable: 50Mbps 100Mbps 200Mbps 300Mbps 400Mbps 500Mbps 1Gbps 2Gbps 5Gbps 10Gbps",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -162,13 +167,13 @@ func resourceAwsReqHostConnRead(ctx context.Context, d *schema.ResourceData, m i
 			_ = d.Set("src_svlan", resp2.Interfaces[0].Svlan) // Port A if ENNI
 		}
 		_ = d.Set("zone", resp2.Interfaces[1].Zone) // Port Z
+		_ = d.Set("po_number", resp2.PONumber)
 	}
 	return diags
 }
 
 func resourceAwsReqHostConnUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*packetfabric.PFClient)
-	return resourceServicesHostedUpdate(ctx, d, m, c.UpdateServiceHostedConn)
+	return resourceServicesHostedUpdate(ctx, d, m)
 }
 
 func extractReqConn(d *schema.ResourceData) packetfabric.HostedAwsConnection {

--- a/internal/provider/resource_aws_hosted_conn.go
+++ b/internal/provider/resource_aws_hosted_conn.go
@@ -205,5 +205,8 @@ func extractReqConn(d *schema.ResourceData) packetfabric.HostedAwsConnection {
 	if speed, ok := d.GetOk("speed"); ok {
 		hostedAwsConn.Speed = speed.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		hostedAwsConn.PONumber = poNumber.(string)
+	}
 	return hostedAwsConn
 }

--- a/internal/provider/resource_azure_cloud_router_connection.go
+++ b/internal/provider/resource_azure_cloud_router_connection.go
@@ -90,6 +90,11 @@ func resourceAzureExpressRouteConn() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: CloudRouterImportStatePassthroughContext,
@@ -151,6 +156,7 @@ func resourceAzureExpressRouteConnRead(ctx context.Context, d *schema.ResourceDa
 		_ = d.Set("description", resp.Description)
 		_ = d.Set("speed", resp.Speed)
 		_ = d.Set("azure_service_key", resp.CloudSettings.AzureServiceKey)
+		_ = d.Set("po_number", resp.PONumber)
 
 		if resp.CloudSettings.PublicIP != "" {
 			_ = d.Set("is_public", true)

--- a/internal/provider/resource_azure_cloud_router_connection.go
+++ b/internal/provider/resource_azure_cloud_router_connection.go
@@ -91,9 +91,10 @@ func resourceAzureExpressRouteConn() *schema.Resource {
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_azure_cloud_router_connection.go
+++ b/internal/provider/resource_azure_cloud_router_connection.go
@@ -199,5 +199,8 @@ func extractAzureExpressRouteConn(d *schema.ResourceData) packetfabric.AzureExpr
 	if publishedQuoteLine, ok := d.GetOk("published_quote_line_uuid"); ok {
 		expressRoute.PublishedQuoteLineUUID = publishedQuoteLine.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		expressRoute.PONumber = poNumber.(string)
+	}
 	return expressRoute
 }

--- a/internal/provider/resource_azure_dedicated_conn.go
+++ b/internal/provider/resource_azure_dedicated_conn.go
@@ -207,6 +207,7 @@ func extractAzureExpressDedicatedConn(d *schema.ResourceData) packetfabric.Azure
 		Encapsulation:          d.Get("encapsulation").(string),
 		PortCategory:           d.Get("port_category").(string),
 		PublishedQuoteLineUUID: d.Get("published_quote_line_uuid").(string),
+		PONumber:               d.Get("po_number").(string),
 	}
 	return azureExpress
 }

--- a/internal/provider/resource_azure_dedicated_conn.go
+++ b/internal/provider/resource_azure_dedicated_conn.go
@@ -104,6 +104,11 @@ func resourceAzureReqExpressDedicatedConn() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -170,6 +175,7 @@ func resourceAzureReqExpressDedicatedConnRead(ctx context.Context, d *schema.Res
 	}
 	if resp2 != nil {
 		_ = d.Set("zone", resp2.Zone)
+		_ = d.Set("po_number", resp2.PONumber)
 		if resp2.IsLag {
 			_ = d.Set("should_create_lag", true)
 		} else {
@@ -181,8 +187,7 @@ func resourceAzureReqExpressDedicatedConnRead(ctx context.Context, d *schema.Res
 }
 
 func resourceAzureReqExpressDedicatedConnUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*packetfabric.PFClient)
-	return resourceServicesDedicatedUpdate(ctx, d, m, c.UpdateServiceHostedConn)
+	return resourceServicesDedicatedUpdate(ctx, d, m)
 }
 
 func resourceAzureReqExpressDedicatedConnDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/internal/provider/resource_azure_dedicated_conn.go
+++ b/internal/provider/resource_azure_dedicated_conn.go
@@ -105,9 +105,10 @@ func resourceAzureReqExpressDedicatedConn() *schema.Resource {
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_azure_hosted_conn.go
+++ b/internal/provider/resource_azure_hosted_conn.go
@@ -195,5 +195,8 @@ func extractAzureExpressConn(d *schema.ResourceData) packetfabric.AzureExpressRo
 	if speed, ok := d.GetOk("speed"); ok {
 		azureExpress.Speed = speed.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		azureExpress.PONumber = poNumber.(string)
+	}
 	return azureExpress
 }

--- a/internal/provider/resource_azure_hosted_conn.go
+++ b/internal/provider/resource_azure_hosted_conn.go
@@ -82,6 +82,11 @@ func resourceAzureReqExpressHostedConn() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(speedOptions(), true),
 				Description:  "The peed of the new connection.\n\n\tEnum: [\"50Mbps\" \"100Mbps\" \"200Mbps\" \"300Mbps\" \"400Mbps\" \"500Mbps\" \"1Gbps\" \"2Gbps\" \"5Gbps\" \"10Gbps\"]",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -151,13 +156,13 @@ func resourceAzureReqExpressHostedConnRead(ctx context.Context, d *schema.Resour
 			_ = d.Set("src_svlan", resp2.Interfaces[0].Svlan) // Port A if ENNI
 		}
 		_ = d.Set("zone", resp2.Interfaces[1].Zone) // Port Z
+		_ = d.Set("po_number", resp2.PONumber)
 	}
 	return diags
 }
 
 func resourceAzureReqExpressHostedConnUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*packetfabric.PFClient)
-	return resourceServicesHostedUpdate(ctx, d, m, c.UpdateServiceHostedConn)
+	return resourceServicesHostedUpdate(ctx, d, m)
 }
 
 func resourceAzureReqExpressHostedConnDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/internal/provider/resource_azure_hosted_conn.go
+++ b/internal/provider/resource_azure_hosted_conn.go
@@ -83,9 +83,10 @@ func resourceAzureReqExpressHostedConn() *schema.Resource {
 				Description:  "The peed of the new connection.\n\n\tEnum: [\"50Mbps\" \"100Mbps\" \"200Mbps\" \"300Mbps\" \"400Mbps\" \"500Mbps\" \"1Gbps\" \"2Gbps\" \"5Gbps\" \"10Gbps\"]",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_backbone.go
+++ b/internal/provider/resource_backbone.go
@@ -145,6 +145,11 @@ func resourceBackbone() *schema.Resource {
 				ForceNew:    true,
 				Description: "ID of the flex bandwidth container from which to subtract this VC's speed.",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -270,6 +275,7 @@ func resourceBackboneRead(ctx context.Context, d *schema.ResourceData, m interfa
 		} else {
 			_ = d.Set("flex_bandwidth_id", nil)
 		}
+		_ = d.Set("po_number", resp.PONumber)
 	}
 	return diags
 }
@@ -394,6 +400,9 @@ func extractServiceSettings(d *schema.ResourceData) packetfabric.ServiceSettings
 				settUpdate.Interfaces = append(settUpdate.Interfaces, extractBackboneInterface(interf.(map[string]interface{})))
 			}
 		}
+	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		settUpdate.PONumber = poNumber.(string)
 	}
 
 	return settUpdate

--- a/internal/provider/resource_backbone.go
+++ b/internal/provider/resource_backbone.go
@@ -146,9 +146,10 @@ func resourceBackbone() *schema.Resource {
 				Description: "ID of the flex bandwidth container from which to subtract this VC's speed.",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_backbone.go
+++ b/internal/provider/resource_backbone.go
@@ -368,6 +368,9 @@ func extractBack(d *schema.ResourceData) packetfabric.Backbone {
 	if flexBandID, ok := d.GetOk("flex_bandwidth_id"); ok {
 		backboneVC.FlexBandwidthID = flexBandID.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		backboneVC.PONumber = poNumber.(string)
+	}
 	return backboneVC
 }
 

--- a/internal/provider/resource_cloud_router.go
+++ b/internal/provider/resource_cloud_router.go
@@ -64,6 +64,11 @@ func resourceCloudRouter() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 				Description:  "The cloud router capacity.\n\n\tEnum: \"100Mbps\" \"500Mbps\" \"1Gbps\" \"2Gbps\" \"5Gbps\" \"10Gbps\" \"20Gbps\" \"30Gbps\" \"40Gbps\" \"50Gbps\" \"60Gbps\" \"80Gbps\" \"100Gbps\" \">100Gbps\"",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -111,6 +116,7 @@ func resourceCloudRouterRead(ctx context.Context, d *schema.ResourceData, m inte
 			regions = append(regions, region.Code)
 		}
 		_ = d.Set("regions", regions)
+		_ = d.Set("po_number", resp.PONumber)
 	}
 	return diags
 }
@@ -136,6 +142,7 @@ func resourceCloudRouterUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 	_ = d.Set("name", resp.Name)
 	_ = d.Set("capacity", resp.Capacity)
+	_ = d.Set("po_number", resp.PONumber)
 	return diags
 }
 

--- a/internal/provider/resource_cloud_router.go
+++ b/internal/provider/resource_cloud_router.go
@@ -177,6 +177,9 @@ func extractCloudRouter(d *schema.ResourceData) packetfabric.CloudRouter {
 	if capacity, ok := d.GetOk("capacity"); ok {
 		router.Capacity = capacity.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		router.PONumber = poNumber.(string)
+	}
 	router.Regions = extractRegions(d)
 	return router
 }

--- a/internal/provider/resource_cloud_router.go
+++ b/internal/provider/resource_cloud_router.go
@@ -65,9 +65,10 @@ func resourceCloudRouter() *schema.Resource {
 				Description:  "The cloud router capacity.\n\n\tEnum: \"100Mbps\" \"500Mbps\" \"1Gbps\" \"2Gbps\" \"5Gbps\" \"10Gbps\" \"20Gbps\" \"30Gbps\" \"40Gbps\" \"50Gbps\" \"60Gbps\" \"80Gbps\" \"100Gbps\" \">100Gbps\"",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_cloud_router_connection_common.go
+++ b/internal/provider/resource_cloud_router_connection_common.go
@@ -30,14 +30,16 @@ func resourceCloudRouterConnUpdate(ctx context.Context, d *schema.ResourceData, 
 	var diags diag.Diagnostics
 
 	if cid, ok := d.GetOk("circuit_id"); ok {
-		if d.HasChange("description") {
+		if d.HasChange("description") || d.HasChange("po_number") {
+			updateData := packetfabric.CloudRouterUpdateData{}
 			if desc, descOk := d.GetOk("description"); descOk {
-				descUpdate := packetfabric.DescriptionUpdate{
-					Description: desc.(string),
-				}
-				if _, err := c.UpdateCloudRouterConnection(cid.(string), d.Id(), descUpdate); err != nil {
-					return diag.FromErr(err)
-				}
+				updateData.Description = desc.(string)
+			}
+			if poNumber, ok := d.GetOk("po_number"); ok {
+				updateData.PONumber = poNumber.(string)
+			}
+			if _, err := c.UpdateCloudRouterConnection(cid.(string), d.Id(), updateData); err != nil {
+				return diag.FromErr(err)
 			}
 		}
 		if d.HasChange("speed") {

--- a/internal/provider/resource_cloud_service_common.go
+++ b/internal/provider/resource_cloud_service_common.go
@@ -9,7 +9,7 @@ import (
 )
 
 // used for all Hosted Clouds
-func resourceServicesHostedUpdate(ctx context.Context, d *schema.ResourceData, m interface{}, fn func(string, string) (*packetfabric.CloudServiceConnCreateResp, error)) diag.Diagnostics {
+func resourceServicesHostedUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*packetfabric.PFClient)
 	c.Ctx = ctx
 	var diags diag.Diagnostics
@@ -17,17 +17,22 @@ func resourceServicesHostedUpdate(ctx context.Context, d *schema.ResourceData, m
 	if !ok {
 		return diag.Errorf("please provide a valid cloud service id")
 	}
+
 	if d.HasChange("description") {
-		if desc, ok := d.GetOk("description"); !ok {
+		updateServiceConnData := packetfabric.UpdateServiceConn{}
+		desc, ok := d.GetOk("description")
+		if !ok {
 			return diag.Errorf("please provide a valid description for Cloud Service")
+		}
+		updateServiceConnData.Description = desc.(string)
+
+		if resp, err := c.UpdateServiceHostedConn(cloudCID.(string), updateServiceConnData); err != nil {
+			return diag.FromErr(err)
 		} else {
-			resp, err := fn(desc.(string), cloudCID.(string))
-			if err != nil {
-				return diag.FromErr(err)
-			}
 			_ = d.Set("description", resp.Description)
 		}
 	}
+
 	if d.HasChange("speed") {
 		billing := packetfabric.BillingUpgrade{}
 		if speed, ok := d.GetOk("speed"); ok {
@@ -44,7 +49,7 @@ func resourceServicesHostedUpdate(ctx context.Context, d *schema.ResourceData, m
 }
 
 // used for all Dedicated Clouds
-func resourceServicesDedicatedUpdate(ctx context.Context, d *schema.ResourceData, m interface{}, fn func(string, string) (*packetfabric.CloudServiceConnCreateResp, error)) diag.Diagnostics {
+func resourceServicesDedicatedUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*packetfabric.PFClient)
 	c.Ctx = ctx
 	var diags diag.Diagnostics
@@ -69,6 +74,17 @@ func resourceServicesDedicatedUpdate(ctx context.Context, d *schema.ResourceData
 		}
 		if serviceClass, ok := d.GetOk("service_class"); ok {
 			_ = d.Set("service_class", serviceClass.(string))
+		}
+	}
+
+	if d.HasChanges([]string{"po_number", "description", "autoneg"}...) {
+		portUpdateData := packetfabric.PortUpdate{
+			Description: d.Get("description").(string),
+			Autoneg:     d.Get("autoneg").(bool),
+			PONumber:    d.Get("po_number").(string),
+		}
+		if _, err := c.UpdatePort(d.Id(), portUpdateData); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 	return diags

--- a/internal/provider/resource_google_cloud_router_connection.go
+++ b/internal/provider/resource_google_cloud_router_connection.go
@@ -211,5 +211,8 @@ func extractGoogleRouteConn(d *schema.ResourceData) packetfabric.GoogleCloudRout
 	if publishedQuoteLine, ok := d.GetOk("published_quote_line_uuid"); ok {
 		googleRoute.PublishedQuoteLineUUID = publishedQuoteLine.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		googleRoute.PONumber = poNumber.(string)
+	}
 	return googleRoute
 }

--- a/internal/provider/resource_google_cloud_router_connection.go
+++ b/internal/provider/resource_google_cloud_router_connection.go
@@ -97,9 +97,10 @@ func resourceGoogleCloudRouterConn() *schema.Resource {
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_google_cloud_router_connection.go
+++ b/internal/provider/resource_google_cloud_router_connection.go
@@ -96,6 +96,11 @@ func resourceGoogleCloudRouterConn() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: CloudRouterImportStatePassthroughContext,
@@ -157,6 +162,7 @@ func resourceGoogleCloudRouterConnRead(ctx context.Context, d *schema.ResourceDa
 		_ = d.Set("pop", resp.Pop)
 		_ = d.Set("google_pairing_key", resp.CloudSettings.GooglePairingKey)
 		_ = d.Set("google_vlan_attachment_name", resp.CloudSettings.GoogleVlanAttachmentName)
+		_ = d.Set("po_number", resp.PONumber)
 
 		if resp.CloudSettings.PublicIP != "" {
 			_ = d.Set("is_public", true)

--- a/internal/provider/resource_google_dedicated_conn.go
+++ b/internal/provider/resource_google_dedicated_conn.go
@@ -96,6 +96,11 @@ func resourceGoogleDedicatedConn() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -165,6 +170,7 @@ func resourceGoogleDedicatedConnRead(ctx context.Context, d *schema.ResourceData
 	if resp2 != nil {
 		_ = d.Set("autoneg", resp2.Autoneg)
 		_ = d.Set("zone", resp2.Zone)
+		_ = d.Set("po_number", resp2.PONumber)
 		if resp2.IsLag {
 			_ = d.Set("should_create_lag", true)
 		} else {
@@ -176,8 +182,7 @@ func resourceGoogleDedicatedConnRead(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceGoogleDedicatedConnUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*packetfabric.PFClient)
-	return resourceServicesDedicatedUpdate(ctx, d, m, c.UpdateServiceDedicatedConn)
+	return resourceServicesDedicatedUpdate(ctx, d, m)
 }
 
 func resourceGoogleDedicatedConnDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/internal/provider/resource_google_dedicated_conn.go
+++ b/internal/provider/resource_google_dedicated_conn.go
@@ -221,5 +221,8 @@ func extractGoogleDedicatedConn(d *schema.ResourceData) packetfabric.GoogleReqDe
 	if publishedQuote, ok := d.GetOk("published_quote_line_uuid"); ok {
 		dedicatedConn.PublishedQuoteLineUUID = publishedQuote.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		dedicatedConn.PONumber = poNumber.(string)
+	}
 	return dedicatedConn
 }

--- a/internal/provider/resource_google_dedicated_conn.go
+++ b/internal/provider/resource_google_dedicated_conn.go
@@ -97,9 +97,10 @@ func resourceGoogleDedicatedConn() *schema.Resource {
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_google_hosted_conn.go
+++ b/internal/provider/resource_google_hosted_conn.go
@@ -88,6 +88,11 @@ func resourceGoogleRequestHostConn() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(speedOptions(), true),
 				Description:  "The speed of the new connection.\n\n\t Available: 50Mbps 100Mbps 200Mbps 300Mbps 400Mbps 500Mbps 1Gbps 2Gbps 5Gbps 10Gbps",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -167,13 +172,13 @@ func resourceGoogleReqHostConnRead(ctx context.Context, d *schema.ResourceData, 
 			_ = d.Set("src_svlan", resp2.Interfaces[0].Svlan) // Port A if ENNI
 		}
 		_ = d.Set("zone", resp2.Interfaces[1].Zone) // Port Z
+		_ = d.Set("po_number", resp2.PONumber)
 	}
 	return diags
 }
 
 func resourceGoogleReqHostConnUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*packetfabric.PFClient)
-	return resourceServicesHostedUpdate(ctx, d, m, c.UpdateServiceHostedConn)
+	return resourceServicesHostedUpdate(ctx, d, m)
 }
 
 func resourceGoogeReqHostConnDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/internal/provider/resource_google_hosted_conn.go
+++ b/internal/provider/resource_google_hosted_conn.go
@@ -214,5 +214,8 @@ func extractGoogleReqConn(d *schema.ResourceData) packetfabric.GoogleReqHostedCo
 	if speed, ok := d.GetOk("speed"); ok {
 		googleHosted.Speed = speed.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		googleHosted.PONumber = poNumber.(string)
+	}
 	return googleHosted
 }

--- a/internal/provider/resource_google_hosted_conn.go
+++ b/internal/provider/resource_google_hosted_conn.go
@@ -89,9 +89,10 @@ func resourceGoogleRequestHostConn() *schema.Resource {
 				Description:  "The speed of the new connection.\n\n\t Available: 50Mbps 100Mbps 200Mbps 300Mbps 400Mbps 500Mbps 1Gbps 2Gbps 5Gbps 10Gbps",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_ibm_hosted_conn.go
+++ b/internal/provider/resource_ibm_hosted_conn.go
@@ -261,5 +261,8 @@ func extractHostedIBMConn(d *schema.ResourceData) packetfabric.HostedIBMConn {
 	if speed, ok := d.GetOk("speed"); ok {
 		hostedConn.Speed = speed.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		hostedConn.PONumber = poNumber.(string)
+	}
 	return hostedConn
 }

--- a/internal/provider/resource_ibm_hosted_conn.go
+++ b/internal/provider/resource_ibm_hosted_conn.go
@@ -120,9 +120,10 @@ func resourceHostedIbmConn() *schema.Resource {
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_ibm_hosted_conn.go
+++ b/internal/provider/resource_ibm_hosted_conn.go
@@ -119,6 +119,11 @@ func resourceHostedIbmConn() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -204,14 +209,14 @@ func resourceHostedIbmConnRead(ctx context.Context, d *schema.ResourceData, m in
 			_ = d.Set("src_svlan", resp2.Interfaces[0].Svlan) // Port A if ENNI
 		}
 		_ = d.Set("zone", resp2.Interfaces[1].Zone) // Port Z
+		_ = d.Set("po_number", resp2.PONumber)
 	}
 	// unsetFields: published_quote_line_uuid
 	return diags
 }
 
 func resourceHostedIbmConnUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*packetfabric.PFClient)
-	return resourceServicesHostedUpdate(ctx, d, m, c.UpdateServiceHostedConn)
+	return resourceServicesHostedUpdate(ctx, d, m)
 }
 
 func resourceHostedIbmConnDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/internal/provider/resource_ibm_route_cloud_connection.go
+++ b/internal/provider/resource_ibm_route_cloud_connection.go
@@ -231,5 +231,8 @@ func extractIBMCloudRouterConn(d *schema.ResourceData) packetfabric.IBMCloudRout
 	if publishedQuote, ok := d.GetOk("published_quote_line_uuid"); ok {
 		ibmRouter.PublishedQuoteLineUUID = publishedQuote.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		ibmRouter.PONumber = poNumber.(string)
+	}
 	return ibmRouter
 }

--- a/internal/provider/resource_ibm_route_cloud_connection.go
+++ b/internal/provider/resource_ibm_route_cloud_connection.go
@@ -119,6 +119,11 @@ func resourceIBMCloudRouteConn() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: CloudRouterImportStatePassthroughContext,
@@ -174,6 +179,7 @@ func resourceIBMCloudRouteConnRead(ctx context.Context, d *schema.ResourceData, 
 		_ = d.Set("pop", resp.Pop)
 		_ = d.Set("speed", resp.Speed)
 		_ = d.Set("zone", resp.Zone)
+		_ = d.Set("po_number", resp.PONumber)
 		// unsetFields: published_quote_line_uuid
 	}
 	return diags

--- a/internal/provider/resource_ibm_route_cloud_connection.go
+++ b/internal/provider/resource_ibm_route_cloud_connection.go
@@ -120,9 +120,10 @@ func resourceIBMCloudRouteConn() *schema.Resource {
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_ipsec_route_cloud_connection.go
+++ b/internal/provider/resource_ipsec_route_cloud_connection.go
@@ -239,7 +239,7 @@ func resourceIPSecCloudRouteConnUpdate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	if d.HasChange("description") || d.HasChange("speed") || d.HasChange("po_number") {
+	if d.HasChanges([]string{"description", "speed", "po_number"}...) {
 		return resourceCloudRouterConnUpdate(ctx, d, m)
 	}
 

--- a/internal/provider/resource_ipsec_route_cloud_connection.go
+++ b/internal/provider/resource_ipsec_route_cloud_connection.go
@@ -141,6 +141,11 @@ func resourceIPSecCloudRouteConn() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: CloudRouterImportStatePassthroughContext,
@@ -217,6 +222,7 @@ func resourceIPSecCloudRouteConnRead(ctx context.Context, d *schema.ResourceData
 		_ = d.Set("phase2_lifetime", resp2.Phase2Lifetime)
 		_ = d.Set("gateway_address", resp2.CustomerGatewayAddress)
 		_ = d.Set("shared_key", resp2.PreSharedKey)
+		_ = d.Set("po_number", resp.PONumber)
 		// unsetFields: published_quote_line_uuid
 	}
 	return diags
@@ -233,7 +239,7 @@ func resourceIPSecCloudRouteConnUpdate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	if d.HasChange("description") || d.HasChange("speed") {
+	if d.HasChange("description") || d.HasChange("speed") || d.HasChange("po_number") {
 		return resourceCloudRouterConnUpdate(ctx, d, m)
 	}
 

--- a/internal/provider/resource_ipsec_route_cloud_connection.go
+++ b/internal/provider/resource_ipsec_route_cloud_connection.go
@@ -142,9 +142,10 @@ func resourceIPSecCloudRouteConn() *schema.Resource {
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_ipsec_route_cloud_connection.go
+++ b/internal/provider/resource_ipsec_route_cloud_connection.go
@@ -303,6 +303,9 @@ func extractIPSecRouteConn(d *schema.ResourceData) (packetfabric.IPSecRouterConn
 	if publishedQuote, ok := d.GetOk("published_quote_line_uuid"); ok {
 		iPSecRouter.PublishedQuoteLineUUID = publishedQuote.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		iPSecRouter.PONumber = poNumber.(string)
+	}
 	return iPSecRouter, nil
 }
 

--- a/internal/provider/resource_link_aggregation_groups.go
+++ b/internal/provider/resource_link_aggregation_groups.go
@@ -128,8 +128,8 @@ func updatePort(c *packetfabric.PFClient, d *schema.ResourceData) (diag.Diagnost
 	if err2 != nil {
 		return diag.FromErr(err), false
 	}
-	
-	return nil, true
+
+	return diag.Diagnostics{}, true
 }
 
 func resourceLinkAggregationGroupsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/internal/provider/resource_link_aggregation_groups.go
+++ b/internal/provider/resource_link_aggregation_groups.go
@@ -58,9 +58,10 @@ func resourceLinkAggregationGroups() *schema.Resource {
 				},
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_link_aggregation_groups.go
+++ b/internal/provider/resource_link_aggregation_groups.go
@@ -104,7 +104,6 @@ func resourceLinkAggregationGroupsUpdate(ctx context.Context, d *schema.Resource
 			return diagnostics
 		}
 	}
-
 	return diags
 }
 
@@ -128,8 +127,7 @@ func updatePort(c *packetfabric.PFClient, d *schema.ResourceData) (diag.Diagnost
 	if err2 != nil {
 		return diag.FromErr(err), false
 	}
-
-	return diag.Diagnostics{}, true
+	return nil, true
 }
 
 func resourceLinkAggregationGroupsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/internal/provider/resource_link_aggregation_groups.go
+++ b/internal/provider/resource_link_aggregation_groups.go
@@ -127,7 +127,7 @@ func updatePort(c *packetfabric.PFClient, d *schema.ResourceData) (diag.Diagnost
 	if err2 != nil {
 		return diag.FromErr(err), false
 	}
-	return nil, true
+	return diag.Diagnostics{}, true
 }
 
 func resourceLinkAggregationGroupsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/internal/provider/resource_oracle_cloud_router_connection.go
+++ b/internal/provider/resource_oracle_cloud_router_connection.go
@@ -98,6 +98,11 @@ func resourceOracleCloudRouteConn() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: CloudRouterImportStatePassthroughContext,
@@ -159,6 +164,7 @@ func resourceOracleCloudRouteConnRead(ctx context.Context, d *schema.ResourceDat
 		_ = d.Set("description", resp.Description)
 		_ = d.Set("pop", resp.Pop)
 		_ = d.Set("zone", resp.Zone)
+		_ = d.Set("po_number", resp.PONumber)
 		// unsetFields: published_quote_line_uuid
 	}
 	return diags

--- a/internal/provider/resource_oracle_cloud_router_connection.go
+++ b/internal/provider/resource_oracle_cloud_router_connection.go
@@ -99,9 +99,10 @@ func resourceOracleCloudRouteConn() *schema.Resource {
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_oracle_cloud_router_connection.go
+++ b/internal/provider/resource_oracle_cloud_router_connection.go
@@ -207,5 +207,8 @@ func extractOracleCloudRouterConn(d *schema.ResourceData) packetfabric.OracleClo
 	if publishedQuote, ok := d.GetOk("published_quote_line_uuid"); ok {
 		oracleRouter.PublishedQuoteLineUUID = publishedQuote.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		oracleRouter.PONumber = poNumber.(string)
+	}
 	return oracleRouter
 }

--- a/internal/provider/resource_oracle_hosted_conn.go
+++ b/internal/provider/resource_oracle_hosted_conn.go
@@ -229,5 +229,8 @@ func extractOracleHostedConn(d *schema.ResourceData) packetfabric.CloudServiceOr
 	if pubQuoteLineUUID, ok := d.GetOk("published_quote_line_uuid"); ok {
 		oracleConn.PublishedQuoteLineUUID = pubQuoteLineUUID.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		oracleConn.PONumber = poNumber.(string)
+	}
 	return oracleConn
 }

--- a/internal/provider/resource_oracle_hosted_conn.go
+++ b/internal/provider/resource_oracle_hosted_conn.go
@@ -99,9 +99,10 @@ func resourceOracleHostedConn() *schema.Resource {
 				Description:  "UUID of the published quote line with this connection should be associated.",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_oracle_hosted_conn.go
+++ b/internal/provider/resource_oracle_hosted_conn.go
@@ -98,6 +98,11 @@ func resourceOracleHostedConn() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "UUID of the published quote line with this connection should be associated.",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -167,14 +172,14 @@ func resourceOracleHostedConnRead(ctx context.Context, d *schema.ResourceData, m
 			_ = d.Set("src_svlan", resp2.Interfaces[0].Svlan) // Port A if ENNI
 		}
 		_ = d.Set("zone", resp2.Interfaces[1].Zone) // Port Z
+		_ = d.Set("po_number", resp2.PONumber)
 	}
 	// unsetFields: published_quote_line_uuid
 	return diags
 }
 
 func resourceOracleHostedConnUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*packetfabric.PFClient)
-	return resourceServicesHostedUpdate(ctx, d, m, c.UpdateServiceHostedConn)
+	return resourceServicesHostedUpdate(ctx, d, m)
 }
 
 func resourceOracleHostedConnDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/internal/provider/resource_point_to_point.go
+++ b/internal/provider/resource_point_to_point.go
@@ -298,6 +298,9 @@ func extractPtpService(d *schema.ResourceData) packetfabric.PointToPoint {
 	if quote, ok := d.GetOk("published_quote_line_uuid"); ok {
 		ptpService.PublishedQuoteLineUUID = quote.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		ptpService.PONumber = poNumber.(string)
+	}
 	return ptpService
 }
 

--- a/internal/provider/resource_point_to_point.go
+++ b/internal/provider/resource_point_to_point.go
@@ -118,9 +118,10 @@ func resourcePointToPoint() *schema.Resource {
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_port.go
+++ b/internal/provider/resource_port.go
@@ -189,6 +189,7 @@ func extractInterface(d *schema.ResourceData) packetfabric.Interface {
 		Speed:            d.Get("speed").(string),
 		SubscriptionTerm: d.Get("subscription_term").(int),
 		Zone:             d.Get("zone").(string),
+		PONumber:         d.Get("po_number").(string),
 	}
 	if autoneg, ok := d.GetOk("autoneg"); ok {
 		interf.Autoneg = autoneg.(bool)

--- a/internal/provider/resource_port.go
+++ b/internal/provider/resource_port.go
@@ -95,9 +95,10 @@ func resourceInterfaces() *schema.Resource {
 				Description: "Change Port Admin Status. Set it to true when port is enabled, false when port is disabled. ",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_port.go
+++ b/internal/provider/resource_port.go
@@ -94,6 +94,11 @@ func resourceInterfaces() *schema.Resource {
 				Default:     true,
 				Description: "Change Port Admin Status. Set it to true when port is enabled, false when port is disabled. ",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -141,6 +146,7 @@ func resourceReadInterface(ctx context.Context, d *schema.ResourceData, m interf
 		_ = d.Set("speed", resp.Speed)
 		_ = d.Set("subscription_term", resp.SubscriptionTerm)
 		_ = d.Set("zone", resp.Zone)
+		_ = d.Set("po_number", resp.PONumber)
 		if resp.Disabled {
 			_ = d.Set("enabled", false)
 		} else {
@@ -195,17 +201,15 @@ func _extractUpdateFn(ctx context.Context, d *schema.ResourceData, m interface{}
 	c.Ctx = ctx
 
 	// Update if payload contains Autoneg and Description
-	if d.HasChange("description") && d.HasChange("autoneg") {
-		resp, err = c.UpdatePort(d.Get("autoneg").(bool), d.Id(), d.Get("description").(string))
+	if d.HasChanges([]string{"po_number", "description", "autoneg"}...) {
+		portUpdateData := packetfabric.PortUpdate{
+			Description: d.Get("description").(string),
+			Autoneg:     d.Get("autoneg").(bool),
+			PONumber:    d.Get("po_number").(string),
+		}
+		resp, err = c.UpdatePort(d.Id(), portUpdateData)
 	}
-	// Update if payload contains Description only
-	if d.HasChange("description") && !d.HasChange("autoneg") {
-		resp, err = c.UpdatePortDescriptionOnly(d.Id(), d.Get("description").(string))
-	}
-	// Update if payload contains Autoneg only
-	if !d.HasChange("description") && d.HasChange("autoneg") {
-		resp, err = c.UpdatePortAutoNegOnly(d.Get("autoneg").(bool), d.Id())
-	}
+
 	// Update port status
 	if enabledHasChanged := d.HasChange("enabled"); enabledHasChanged {
 		_, enableChange := d.GetChange("enabled")

--- a/internal/provider/resource_port_cloud_router_connection.go
+++ b/internal/provider/resource_port_cloud_router_connection.go
@@ -96,6 +96,11 @@ func resourceCustomerOwnedPortConn() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
+			"po_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Purchase order number or identifier of a service.",
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: CloudRouterImportStatePassthroughContext,
@@ -149,6 +154,7 @@ func resourceCustomerOwnedPortConnRead(ctx context.Context, d *schema.ResourceDa
 		_ = d.Set("description", resp.Description)
 		_ = d.Set("vlan", resp.Vlan)
 		_ = d.Set("speed", resp.Speed)
+		_ = d.Set("po_number", resp.PONumber)
 		if resp.CloudSettings.PublicIP != "" {
 			_ = d.Set("is_public", true)
 		} else {

--- a/internal/provider/resource_port_cloud_router_connection.go
+++ b/internal/provider/resource_port_cloud_router_connection.go
@@ -97,9 +97,10 @@ func resourceCustomerOwnedPortConn() *schema.Resource {
 				Description:  "UUID of the published quote line with which this connection should be associated.",
 			},
 			"po_number": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Purchase order number or identifier of a service.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 32),
+				Description:  "Purchase order number or identifier of a service.",
 			},
 		},
 		Importer: &schema.ResourceImporter{

--- a/internal/provider/resource_port_cloud_router_connection.go
+++ b/internal/provider/resource_port_cloud_router_connection.go
@@ -210,5 +210,8 @@ func extractOwnedPortConn(d *schema.ResourceData) packetfabric.CustomerOwnedPort
 	if publishedQuote, ok := d.GetOk("published_quote_line_uuid"); ok {
 		ownedPort.PublishedQuoteLineUUID = publishedQuote.(string)
 	}
+	if poNumber, ok := d.GetOk("po_number"); ok {
+		ownedPort.PONumber = poNumber.(string)
+	}
 	return ownedPort
 }


### PR DESCRIPTION
## Description
Add `po_number` attribute to the following resources:
- [ ] packetfabric_backbone_virtual_circuit
- [ ] packetfabric_cloud_router
- [ ] packetfabric_cloud_router_connection_aws
- [ ] packetfabric_cloud_router_connection_azure
- [ ] packetfabric_cloud_router_connection_google
- [ ]  packetfabric_cloud_router_connection_ibm
- [ ] packetfabric_cloud_router_connection_ipsec
- [ ] packetfabric_cloud_router_connection_oracle
- [ ] packetfabric_cloud_router_connection_port
- [ ] packetfabric_cs_aws_dedicated_connection
- [ ] packetfabric_cs_aws_hosted_connection
- [ ] packetfabric_cs_azure_dedicated_connection
- [ ] packetfabric_cs_azure_hosted_connection
- [ ] packetfabric_cs_google_dedicated_connection
- [ ] packetfabric_cs_google_hosted_connection
- [ ] packetfabric_cs_ibm_hosted_connection
- [ ] packetfabric_cs_oracle_hosted_connection
- [ ] packetfabric_link_aggregation_group
- [ ] packetfabric_point_to_point
- [ ] packetfabric_port

Closes #354 

## Checklist

- [ ] tested locally
- [x] added/updated docs
