### PR TITLE
Update maybe_nat and maybe_dnat in all packetfabric_cloud_router_connection resources

### DIFF
--- a/docs/resources/packetfabric_cloud_router_connection_aws.md
+++ b/docs/resources/packetfabric_cloud_router_connection_aws.md
@@ -93,8 +93,8 @@ resource "aws_dx_connection_confirmation" "confirmation" {
 ### Optional
 
 - `is_public` (Boolean) Whether PacketFabric should allocate a public IP address for this connection. Set this to true if you intend to use a public VIF on the AWS side. Defaults: false
-- `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection. Defaults: false
-- `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection. Defaults: false
+- `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection.
+- `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection.
 - `published_quote_line_uuid` (String) UUID of the published quote line which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The desired AWS availability zone of the new connection.

--- a/docs/resources/packetfabric_cloud_router_connection_google.md
+++ b/docs/resources/packetfabric_cloud_router_connection_google.md
@@ -65,8 +65,8 @@ output "packetfabric_cloud_router_connection_google" {
 
 ### Optional
 
-- `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection. Defaults: false
-- `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection. Defaults: false
+- `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection.
+- `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/docs/resources/packetfabric_cloud_router_connection_ibm.md
+++ b/docs/resources/packetfabric_cloud_router_connection_ibm.md
@@ -59,8 +59,8 @@ output "packetfabric_cloud_router_connection_ibm" {
 
 - `ibm_bgp_cer_cidr` (String) The IP address in CIDR format for the PacketFabric-side router in the BGP session. If you do not specify an address, IBM will assign one on your behalf.
 - `ibm_bgp_ibm_cidr` (String) The IP address in CIDR format for the IBM-side router in the BGP session. If you do not specify an address, IBM will assign one on your behalf. See the documentation for information on which IP ranges are allowed.
-- `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection. Defaults: false
-- `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection. Defaults: false
+- `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection.
+- `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The desired availability zone of the connection.

--- a/docs/resources/packetfabric_cloud_router_connection_oracle.md
+++ b/docs/resources/packetfabric_cloud_router_connection_oracle.md
@@ -53,8 +53,8 @@ output "packetfabric_cloud_router_connection_oracle" {
 
 ### Optional
 
-- `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection. Defaults: false
-- `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection. Defaults: false
+- `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection.
+- `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `zone` (String) The desired availability zone of the new connection.

--- a/docs/resources/packetfabric_cloud_router_connection_port.md
+++ b/docs/resources/packetfabric_cloud_router_connection_port.md
@@ -54,8 +54,8 @@ output "packetfabric_cloud_router_connection_port" {
 ### Optional
 
 - `is_public` (Boolean) Whether PacketFabric should allocate a public IP address for this connection. Defaults: false
-- `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection. Defaults: false
-- `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection. Defaults: false
+- `maybe_dnat` (Boolean) Set this to true if you intend to use DNAT on this connection.
+- `maybe_nat` (Boolean) Set this to true if you intend to use NAT on this connection.
 - `published_quote_line_uuid` (String) UUID of the published quote line with which this connection should be associated.
 - `untagged` (Boolean) Whether the interface should be untagged. Do not specify a VLAN if this is to be an untagged connection. Defaults: false
 - `vlan` (Number) Valid VLAN range is from 4-4094, inclusive.

--- a/internal/provider/resource_aws_cloud_router_connection.go
+++ b/internal/provider/resource_aws_cloud_router_connection.go
@@ -55,14 +55,12 @@ func resourceRouterConnectionAws() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Default:     false,
 				Description: "Set this to true if you intend to use NAT on this connection. ",
 			},
 			"maybe_dnat": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Default:     false,
 				Description: "Set this to true if you intend to use DNAT on this connection. ",
 			},
 			"description": {
@@ -155,8 +153,6 @@ func resourceRouterConnectionAwsRead(ctx context.Context, d *schema.ResourceData
 
 	_ = d.Set("account_uuid", resp.AccountUUID)
 	_ = d.Set("circuit_id", resp.CloudRouterCircuitID)
-	_ = d.Set("maybe_nat", resp.NatCapable)
-	_ = d.Set("maybe_dnat", resp.DNatCapable)
 	_ = d.Set("description", resp.Description)
 	_ = d.Set("speed", resp.Speed)
 	_ = d.Set("pop", resp.Pop)

--- a/internal/provider/resource_azure_cloud_router_connection.go
+++ b/internal/provider/resource_azure_cloud_router_connection.go
@@ -146,8 +146,6 @@ func resourceAzureExpressRouteConnRead(ctx context.Context, d *schema.ResourceDa
 
 		_ = d.Set("account_uuid", resp.AccountUUID)
 		_ = d.Set("circuit_id", resp.CloudRouterCircuitID)
-		_ = d.Set("maybe_nat", resp.NatCapable)
-		_ = d.Set("maybe_dnat", resp.DNatCapable)
 		_ = d.Set("description", resp.Description)
 		_ = d.Set("speed", resp.Speed)
 		_ = d.Set("azure_service_key", resp.CloudSettings.AzureServiceKey)

--- a/internal/provider/resource_google_cloud_router_connection.go
+++ b/internal/provider/resource_google_cloud_router_connection.go
@@ -47,14 +47,12 @@ func resourceGoogleCloudRouterConn() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Default:     false,
 				Description: "Set this to true if you intend to use NAT on this connection. ",
 			},
 			"maybe_dnat": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Default:     false,
 				Description: "Set this to true if you intend to use DNAT on this connection. ",
 			},
 			"google_pairing_key": {
@@ -150,8 +148,6 @@ func resourceGoogleCloudRouterConnRead(ctx context.Context, d *schema.ResourceDa
 
 		_ = d.Set("account_uuid", resp.AccountUUID)
 		_ = d.Set("circuit_id", resp.CloudRouterCircuitID)
-		_ = d.Set("maybe_nat", resp.NatCapable)
-		_ = d.Set("maybe_dnat", resp.DNatCapable)
 		_ = d.Set("description", resp.Description)
 		_ = d.Set("speed", resp.Speed)
 		_ = d.Set("pop", resp.Pop)

--- a/internal/provider/resource_ibm_route_cloud_connection.go
+++ b/internal/provider/resource_ibm_route_cloud_connection.go
@@ -31,14 +31,12 @@ func resourceIBMCloudRouteConn() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Default:     false,
 				Description: "Set this to true if you intend to use NAT on this connection. ",
 			},
 			"maybe_dnat": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Default:     false,
 				Description: "Set this to true if you intend to use DNAT on this connection. ",
 			},
 			"circuit_id": {
@@ -164,8 +162,6 @@ func resourceIBMCloudRouteConnRead(ctx context.Context, d *schema.ResourceData, 
 		}
 		_ = d.Set("account_uuid", resp.AccountUUID)
 		_ = d.Set("circuit_id", resp.CloudRouterCircuitID)
-		_ = d.Set("maybe_nat", resp.NatCapable)
-		_ = d.Set("maybe_dnat", resp.DNatCapable)
 		_ = d.Set("ibm_account_id", resp.CloudSettings.AccountID)
 		_ = d.Set("ibm_bgp_asn", resp.CloudSettings.BgpAsn)
 		_ = d.Set("ibm_bgp_cer_cidr", resp.CloudSettings.BgpCerCidr)

--- a/internal/provider/resource_oracle_cloud_router_connection.go
+++ b/internal/provider/resource_oracle_cloud_router_connection.go
@@ -38,14 +38,12 @@ func resourceOracleCloudRouteConn() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Default:     false,
 				Description: "Set this to true if you intend to use NAT on this connection. ",
 			},
 			"maybe_dnat": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Default:     false,
 				Description: "Set this to true if you intend to use DNAT on this connection. ",
 			},
 			"vc_ocid": {
@@ -152,8 +150,6 @@ func resourceOracleCloudRouteConnRead(ctx context.Context, d *schema.ResourceDat
 
 		_ = d.Set("account_uuid", resp.AccountUUID)
 		_ = d.Set("circuit_id", resp.CloudRouterCircuitID)
-		_ = d.Set("maybe_nat", resp.NatCapable)
-		_ = d.Set("maybe_dnat", resp.DNatCapable)
 		_ = d.Set("vc_ocid", resp.CloudSettings.VcOcid)
 		_ = d.Set("region", resp.CloudSettings.OracleRegion)
 		_ = d.Set("description", resp.Description)

--- a/internal/provider/resource_port_cloud_router_connection.go
+++ b/internal/provider/resource_port_cloud_router_connection.go
@@ -40,14 +40,12 @@ func resourceCustomerOwnedPortConn() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Default:     false,
 				Description: "Set this to true if you intend to use NAT on this connection. ",
 			},
 			"maybe_dnat": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Default:     false,
 				Description: "Set this to true if you intend to use DNAT on this connection. ",
 			},
 			"port_circuit_id": {
@@ -143,8 +141,6 @@ func resourceCustomerOwnedPortConnRead(ctx context.Context, d *schema.ResourceDa
 
 		_ = d.Set("account_uuid", resp.AccountUUID)
 		_ = d.Set("circuit_id", resp.CloudRouterCircuitID)
-		_ = d.Set("maybe_nat", resp.NatCapable)
-		_ = d.Set("maybe_dnat", resp.DNatCapable)
 		_ = d.Set("port_circuit_id", resp.PortCircuitID)
 		_ = d.Set("description", resp.Description)
 		_ = d.Set("vlan", resp.Vlan)


### PR DESCRIPTION
## Description

Remove `maybe_nat` and `maybe_dnat` default and also from the read cloud router connection function.

We had to make this change because there is no way today to know if a connection has been created with `maybe_nat` or `maybe_dnat`. The `resp.NatCapable` and `resp.DnatCapable` could be set to `true` even though the connection was not set to maybe_nat/dnat to true.

## Checklist

- [x] tested locally
- [x] added/updated docs
