### PR TITLE
Fix update issue with autoneg in packetfabric_port interfaces 10Gbps

### DIFF
--- a/internal/provider/resource_cloud_service_common.go
+++ b/internal/provider/resource_cloud_service_common.go
@@ -85,10 +85,9 @@ func resourceServicesDedicatedUpdate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
-	if d.HasChanges([]string{"po_number", "description", "autoneg"}...) {
+	if d.HasChanges([]string{"po_number", "description"}...) {
 		portUpdateData := packetfabric.PortUpdate{
 			Description: d.Get("description").(string),
-			Autoneg:     d.Get("autoneg").(bool),
 			PONumber:    d.Get("po_number").(string),
 		}
 		if _, err := c.UpdatePort(d.Id(), portUpdateData); err != nil {

--- a/internal/provider/resource_link_aggregation_groups.go
+++ b/internal/provider/resource_link_aggregation_groups.go
@@ -145,7 +145,6 @@ func updatePort(c *packetfabric.PFClient, d *schema.ResourceData) (diag.Diagnost
 	portUpdateData := packetfabric.PortUpdate{
 		Description: lag.Description,
 		PONumber:    poNumber.(string),
-		Autoneg:     lag.Autoneg,
 	}
 	_, err2 := c.UpdatePort(d.Id(), portUpdateData)
 	if err2 != nil {

--- a/internal/provider/resource_port.go
+++ b/internal/provider/resource_port.go
@@ -232,14 +232,18 @@ func _extractUpdateFn(ctx context.Context, d *schema.ResourceData, m interface{}
 	c := m.(*packetfabric.PFClient)
 	c.Ctx = ctx
 
-	// Update if payload contains Autoneg and Description
-	if d.HasChanges([]string{"po_number", "description", "autoneg"}...) {
+	// Update if payload contains description and po_number
+	if d.HasChanges([]string{"po_number", "description"}...) {
 		portUpdateData := packetfabric.PortUpdate{
 			Description: d.Get("description").(string),
-			Autoneg:     d.Get("autoneg").(bool),
 			PONumber:    d.Get("po_number").(string),
 		}
 		resp, err = c.UpdatePort(d.Id(), portUpdateData)
+	}
+
+	// Update autoneg only if speed == 1Gbps
+	if d.HasChange("autoneg") && d.Get("speed").(string) == "1Gbps" {
+		resp, err = c.UpdatePortAutoNegOnly(d.Id(), d.Get("autoneg").(bool))
 	}
 
 	// Update port status


### PR DESCRIPTION
## Description

- Separated autoneg update with description/po_number to handle difference between 1Gbps and 10Gbps
  - add `changePortStateAutoneg()`
  - add `EnablePortAutoneg()` and `DisablePortAutoneg()`
- Removed unused `UpdatePortDescriptionOnly()` and `UpdatePortAutoNegOnly()` functions
- Remove autoneg in LAG and dedicated cloud update functions (not needed)

## Cross-reference

#366

## Checklist

- [x] tested locally
