### PR TITLE
Rename packetfabric_port data-source to packetfabric_ports

### DIFF
--- a/docs/data-sources/packetfabric_ports.md
+++ b/docs/data-sources/packetfabric_ports.md
@@ -6,17 +6,17 @@ description: |-
   
 ---
 
-# packetfabric_port (Data Source)
+# packetfabric_ports (Data Source)
 
 
 ## Example Usage
 
 ```terraform
-data "packetfabric_port" "ports_all" {
+data "packetfabric_ports" "ports_all" {
   provider = packetfabric
 }
 output "packetfabric_ports_all" {
-  value = data.packetfabric_port.ports_all
+  value = data.packetfabric_ports.ports_all
 }
 ```
 

--- a/examples/data-sources/packetfabric_port/data-source.tf
+++ b/examples/data-sources/packetfabric_port/data-source.tf
@@ -1,6 +1,0 @@
-data "packetfabric_port" "ports_all" {
-  provider = packetfabric
-}
-output "packetfabric_ports_all" {
-  value = data.packetfabric_port.ports_all
-}

--- a/examples/data-sources/packetfabric_ports/data-source.tf
+++ b/examples/data-sources/packetfabric_ports/data-source.tf
@@ -1,0 +1,6 @@
+data "packetfabric_ports" "ports_all" {
+  provider = packetfabric
+}
+output "packetfabric_ports_all" {
+  value = data.packetfabric_ports.ports_all
+}

--- a/examples/test.tf
+++ b/examples/test.tf
@@ -125,12 +125,12 @@ resource "random_pet" "name" {}
 #   value = packetfabric_port.port_2
 # }
 
-# data "packetfabric_port" "ports_all" {
+# data "packetfabric_ports" "ports_all" {
 #   provider   = packetfabric
 #   depends_on = [packetfabric_port.port_2]
 # }
 # locals {
-#   port_2_details = toset([for each in data.packetfabric_port.ports_all.interfaces[*] : each if each.port_circuit_id == packetfabric_port.port_2.id])
+#   port_2_details = toset([for each in data.packetfabric_ports.ports_all.interfaces[*] : each if each.port_circuit_id == packetfabric_port.port_2.id])
 # }
 # output "packetfabric_port_2_details" {
 #   value = local.port_2_details

--- a/internal/provider/datasource_ports.go
+++ b/internal/provider/datasource_ports.go
@@ -18,7 +18,7 @@ func datasourceInterfaces() *schema.Resource {
 
 func interfacesSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"interfaces": {
+		"ports": {
 			Type:     schema.TypeList,
 			Computed: true,
 			Elem: &schema.Resource{

--- a/internal/provider/datasource_ports.go
+++ b/internal/provider/datasource_ports.go
@@ -18,7 +18,7 @@ func datasourceInterfaces() *schema.Resource {
 
 func interfacesSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"ports": {
+		"interfaces": {
 			Type:     schema.TypeList,
 			Computed: true,
 			Elem: &schema.Resource{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -131,7 +131,7 @@ func Provider() *schema.Provider {
 			"packetfabric_cs_ibm_hosted_connection":           datasourceHostedIBMConn(),
 			"packetfabric_cs_dedicated_connections":           datasourceDedicatedConn(),
 			"packetfabric_billing":                            dataSourceBilling(),
-			"packetfabric_port":                               datasourceInterfaces(),
+			"packetfabric_ports":                              datasourceInterfaces(),
 			"packetfabric_locations":                          dataSourceLocations(),
 			"packetfabric_link_aggregation_group":             datasourceLinkAggregationGroups(),
 			"packetfabric_outbound_cross_connect":             dataSourceOutboundCrossConnect(),

--- a/templates/data-sources/ports.md.tmpl
+++ b/templates/data-sources/ports.md.tmpl
@@ -6,7 +6,7 @@ description: |-
   
 ---
 
-# packetfabric_port (Data Source)
+# packetfabric_ports (Data Source)
 
 
 ## Example Usage

--- a/templates/data-sources/ports.md.tmpl
+++ b/templates/data-sources/ports.md.tmpl
@@ -11,7 +11,7 @@ description: |-
 
 ## Example Usage
 
-{{tffile "examples/data-sources/packetfabric_port/data-source.tf"}}
+{{tffile "examples/data-sources/packetfabric_ports/data-source.tf"}}
 
 
 {{ .SchemaMarkdown }}


### PR DESCRIPTION
## Description

The existing data-source `packetfabric_port` returns all the ports. We should correctly name the data-source in plural `packetfabric_ports` to reflect the correct behavior.

## Checklist

<!-- Update as needed -->

- [x] tested locally
- [x] added/updated examples
- [x] added/updated docs
