### PR TITLE
Update Examples and Docs for Google and IBM

### DIFF
--- a/docs/resources/packetfabric_cloud_provider_credential_google.md
+++ b/docs/resources/packetfabric_cloud_provider_credential_google.md
@@ -10,6 +10,13 @@ description: |-
 
 Adding Google Cloud Provider credentials to your PacketFabric environment allows you to perform certain tasks from within the PacketFabric portal.
 
+If you have the `GOOGLE_CREDENTIALS` environment variable set up to store a Google service account JSON key, 
+and you have a pretty-printed JSON file named `google_credentials.json`, you can convert it to a single line JSON string using the following command:
+
+```bash
+cat google_credentials.json | jq -c
+```
+
 ## Example Usage
 
 ```terraform

--- a/docs/resources/packetfabric_cloud_router_connection_ibm.md
+++ b/docs/resources/packetfabric_cloud_router_connection_ibm.md
@@ -45,13 +45,13 @@ data "ibm_dl_gateway" "current" {
   depends_on = [time_sleep.wait_ibm_connection]
 }
 data "ibm_resource_group" "existing_rg" {
-  provider   = ibm
-  name       = "My Resource Group"
+  provider = ibm
+  name     = "My Resource Group"
 }
 
 resource "ibm_dl_gateway_action" "confirmation" {
-  provider = ibm
-  gateway  = data.ibm_dl_gateway.current.id
+  provider       = ibm
+  gateway        = data.ibm_dl_gateway.current.id
   resource_group = data.ibm_resource_group.existing_rg.id
   action         = "create_gateway_approve"
   global         = true

--- a/docs/resources/packetfabric_cs_ibm_hosted_connection.md
+++ b/docs/resources/packetfabric_cs_ibm_hosted_connection.md
@@ -35,13 +35,13 @@ data "ibm_dl_gateway" "current" {
   depends_on = [time_sleep.wait_ibm_connection]
 }
 data "ibm_resource_group" "existing_rg" {
-  provider   = ibm
-  name       = "My Resource Group"
+  provider = ibm
+  name     = "My Resource Group"
 }
 
 resource "ibm_dl_gateway_action" "confirmation" {
-  provider = ibm
-  gateway  = data.ibm_dl_gateway.current.id
+  provider       = ibm
+  gateway        = data.ibm_dl_gateway.current.id
   resource_group = data.ibm_resource_group.existing_rg.id
   action         = "create_gateway_approve"
   global         = true

--- a/examples/source_env_var.sh.sample
+++ b/examples/source_env_var.sh.sample
@@ -16,6 +16,7 @@ export ARM_TENANT_ID="00000000-0000-0000-0000-000000000000"
 
 ### Google
 export TF_VAR_gcp_project_id="my-project-id" # used for bash script used with gcloud module
+# To convert a pretty-printed JSON into a single line JSON string: `jq -c '.' google_credentials.json`
 export GOOGLE_CREDENTIALS='{ "type": "service_account", "project_id": "demo-setting-1234", "private_key_id": "1234", "private_key": "-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----\n", "client_email": "demoapi@demo-setting-1234.iam.gserviceaccount.com", "client_id": "102640829015169383380", "auth_uri": "https://accounts.google.com/o/oauth2/auth", "token_uri": "https://oauth2.googleapis.com/token", "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs", "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/demoapi%40demo-setting-1234.iam.gserviceaccount.com" }'
 
 ### Oracle

--- a/examples/use-cases/cloud_router_aws_google/README.md
+++ b/examples/use-cases/cloud_router_aws_google/README.md
@@ -101,6 +101,8 @@ export GOOGLE_CREDENTIALS='{ "type": "service_account", "project_id": "demo-sett
 export TF_VAR_public_key="ssh-rsa AAAA...= user@mac.lan"
 ```
 
+**Note**: To convert a pretty-printed JSON into a single line JSON string: `jq -c '.' google_credentials.json`.
+
 2. Initialize Terraform, create an execution plan and execute the plan.
 
 ```sh

--- a/examples/use-cases/cloud_router_aws_google_no_cloud_side/README.md
+++ b/examples/use-cases/cloud_router_aws_google_no_cloud_side/README.md
@@ -108,6 +108,8 @@ export GOOGLE_CREDENTIALS='{ "type": "service_account", "project_id": "demo-sett
 export TF_VAR_public_key="ssh-rsa AAAA...= user@mac.lan"
 ```
 
+**Note**: To convert a pretty-printed JSON into a single line JSON string: `jq -c '.' google_credentials.json`.
+
 2. Initialize Terraform, create an execution plan and execute the plan.
 
 ```sh

--- a/examples/use-cases/cloud_router_google_azure/README.md
+++ b/examples/use-cases/cloud_router_google_azure/README.md
@@ -96,6 +96,8 @@ export GOOGLE_CREDENTIALS='{ "type": "service_account", "project_id": "demo-sett
 export TF_VAR_public_key="ssh-rsa AAAA...= user@mac.lan"
 ```
 
+**Note**: To convert a pretty-printed JSON into a single line JSON string: `jq -c '.' google_credentials.json`.
+
 2. Initialize Terraform, create an execution plan and execute the plan.
 
 ```sh

--- a/examples/use-cases/cloud_router_google_ipsec/README.md
+++ b/examples/use-cases/cloud_router_google_ipsec/README.md
@@ -73,6 +73,8 @@ export GOOGLE_CREDENTIALS='{ "type": "service_account", "project_id": "demo-sett
 export TF_VAR_public_key="ssh-rsa AAAA...= user@mac.lan"
 ```
 
+**Note**: To convert a pretty-printed JSON into a single line JSON string: `jq -c '.' google_credentials.json`.
+
 2. Initialize Terraform, create an execution plan and execute the plan.
 
 ```sh

--- a/examples/use-cases/hosted_cloud_google/README.md
+++ b/examples/use-cases/hosted_cloud_google/README.md
@@ -66,6 +66,8 @@ export TF_VAR_gcp_project_id="my-project-id" # used for bash script used with gc
 export GOOGLE_CREDENTIALS='{ "type": "service_account", "project_id": "demo-setting-1234", "private_key_id": "1234", "private_key": "-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----\n", "client_email": "demoapi@demo-setting-1234.iam.gserviceaccount.com", "client_id": "102640829015169383380", "auth_uri": "https://accounts.google.com/o/oauth2/auth", "token_uri": "https://oauth2.googleapis.com/token", "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs", "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/demoapi%40demo-setting-1234.iam.gserviceaccount.com" }'
 ```
 
+**Note**: To convert a pretty-printed JSON into a single line JSON string: `jq -c '.' google_credentials.json`.
+
 2. Initialize Terraform, create an execution plan and execute the plan.
 
 ```sh

--- a/templates/resources/cloud_provider_credential_google.md.tmpl
+++ b/templates/resources/cloud_provider_credential_google.md.tmpl
@@ -10,6 +10,13 @@ description: |-
 
 Adding Google Cloud Provider credentials to your PacketFabric environment allows you to perform certain tasks from within the PacketFabric portal.
 
+If you have the `GOOGLE_CREDENTIALS` environment variable set up to store a Google service account JSON key, 
+and you have a pretty-printed JSON file named `google_credentials.json`, you can convert it to a single line JSON string using the following command:
+
+```bash
+cat google_credentials.json | jq -c
+```
+
 ## Example Usage
 
 {{tffile "examples/resources/packetfabric_cloud_provider_credential_google/resource.tf"}}


### PR DESCRIPTION
## Description

Add jq commands to guide on to convert the google credentials from multi-line to single line.
Update IBM docs.

## Checklist

<!-- Update as needed -->

- [x] tested locally
- [x] added/updated examples
- [x] added/updated docs
