### PR TITLE
Add deprecate field to speed in Azure Hosted Cloud resource

### DIFF
--- a/docs/guides/labels.md
+++ b/docs/guides/labels.md
@@ -27,3 +27,5 @@ resource "packetfabric_cloud_router" "cr1" {
   labels   = ["terraform", "dev"]
 }
 ```
+
+Please note, when importing existing infrastructure into Terraform using `terraform import`, the labels attribute will not be imported. However, you can safely reapply labels using Terraform without causing service disruptions. Terraform will detect and resolve any discrepancies between your configuration and the actual state of your resources during the next terraform apply operation.

--- a/docs/resources/packetfabric_cs_azure_hosted_connection.md
+++ b/docs/resources/packetfabric_cs_azure_hosted_connection.md
@@ -52,7 +52,7 @@ resource "packetfabric_cs_azure_hosted_connection" "cs_conn1_hosted_azure" {
 - `azure_service_key` (String) The Service Key provided by Microsoft Azure when you created your ExpressRoute circuit.
 - `description` (String) A brief description of this connection.
 - `port` (String) The circuit ID of the PacketFabric port you wish to connect to Azure. This starts with "PF-AP-".
-- `speed` (String) The peed of the new connection.
+- `speed` (String, Deprecated) The peed of the new connection.
 
 	Enum: ["50Mbps" "100Mbps" "200Mbps" "300Mbps" "400Mbps" "500Mbps" "1Gbps" "2Gbps" "5Gbps" "10Gbps"]
 

--- a/internal/provider/resource_azure_hosted_conn.go
+++ b/internal/provider/resource_azure_hosted_conn.go
@@ -82,6 +82,7 @@ func resourceAzureReqExpressHostedConn() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringInSlice(speedOptions(), true),
 				Description:  "The peed of the new connection.\n\n\tEnum: [\"50Mbps\" \"100Mbps\" \"200Mbps\" \"300Mbps\" \"400Mbps\" \"500Mbps\" \"1Gbps\" \"2Gbps\" \"5Gbps\" \"10Gbps\"]",
+				Deprecated:   "This field is deprecated and will be removed in a future release.",
 			},
 			"po_number": {
 				Type:         schema.TypeString,

--- a/templates/guides/labels.md
+++ b/templates/guides/labels.md
@@ -23,7 +23,9 @@ resource "packetfabric_cloud_router" "cr1" {
   asn      = 4556
   name     = "hello world"
   capacity = "10Gbps"
-  regions  = ["US", "UK"]
+  regions  = ["US"]
   labels   = ["terraform", "dev"]
 }
 ```
+
+Please note, when importing existing infrastructure into Terraform using `terraform import`, the labels attribute will not be imported. However, you can safely reapply labels using Terraform without causing service disruptions. Terraform will detect and resolve any discrepancies between your configuration and the actual state of your resources during the next terraform apply operation.


### PR DESCRIPTION
## Description

- Add deprecate field to speed in Azure Hosted Cloud resource. The speed is set in the Azure side in the ExpressRoute.
- added a note about labels and terraform import

## Checklist

<!-- Update as needed -->

- [x] added/updated docs
