### PR TITLE
Add 15sec delay before doing the GET etl

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 *   @rjouhann
 
 # code
-/internal/  @medzin @solababs @Favouroked @rjouhann
+/internal/  @medzin @solababs @rjouhann
 
 # docs
 /docs/  @caitlinwheeless @rjouhann

--- a/internal/packetfabric/billing.go
+++ b/internal/packetfabric/billing.go
@@ -2,6 +2,7 @@ package packetfabric
 
 import (
 	"fmt"
+	"time"
 )
 
 const billingURI = "/v2/billing/services/%s"
@@ -81,6 +82,8 @@ func (c *PFClient) ModifyBilling(cID string, billing BillingUpgrade) (*BillingUp
 func (c *PFClient) GetEarlyTerminationLiability(circuitID string) (float64, error) {
 	formattedURI := fmt.Sprintf(etlURI, circuitID)
 	var resp float64
+	// Add a delay of 15 seconds to allow the billing system to catch up
+	time.Sleep(15 * time.Second)
 	_, err := c.sendRequest(formattedURI, getMethod, nil, &resp)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Description

Add 15sec delay before doing the GET etl to avoid this error:

```
 Error: Status: 404, body: {"message": "No Aggregate Capacity, Port, Cloud, Point-to-Point, or Virtual Circuit found with ID \"PF-AE-LAB5-3630387\"", "request_id": "00e1655b-f5e4-4769-a377-5b67f4187e2d"}
```

## Checklist

<!-- Update as needed -->

- [x] tested locally
