### PR TITLE
Fix azure Public IP check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6.1  (June 13, 2023)
+
+BUG FIXES:
+
+* Fix handling of Public IP for Azure Cloud Router Connections (#530)
+
 ## 1.6.0  (May 25, 2023)
 
 BREAKING CHANGES:

--- a/internal/packetfabric/cloud_service_aws.go
+++ b/internal/packetfabric/cloud_service_aws.go
@@ -167,6 +167,8 @@ type CloudSettings struct {
 	PortCrossConnectOcid           string       `json:"port_cross_connect_ocid,omitempty"`
 	PortID                         string       `json:"port_id,omitempty"`
 	PublicIP                       string       `json:"public_ip,omitempty"`
+	PrimaryPublicIP                string       `json:"primary_public_ip,omitempty"`
+	SecondaryPublicIP              string       `json:"secondary_public_ip,omitempty"`
 	SvlanIDCust                    int          `json:"svlan_id_cust,omitempty"`
 	VcOcid                         string       `json:"vc_ocid,omitempty"`
 	VlanIDCust                     int          `json:"vlan_id_cust,omitempty"`

--- a/internal/provider/datasource_cloud_connection.go
+++ b/internal/provider/datasource_cloud_connection.go
@@ -238,6 +238,14 @@ func dataSourceCloudConnection() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"primary_public_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"secondary_public_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"nat_public_ip": {
 							Type:     schema.TypeString,
 							Computed: true,

--- a/internal/provider/datasource_cloud_connections.go
+++ b/internal/provider/datasource_cloud_connections.go
@@ -481,6 +481,8 @@ func flattenCloudSettings(setts *packetfabric.CloudSettings) []interface{} {
 		flatten["vlan_id_microsoft"] = setts.VlanMicrosoft
 		flatten["vlan_id_pf"] = setts.VlanIDPf
 		flatten["vlan_id_private"] = setts.VlanPrivate
+		flatten["primary_public_ip"] = setts.PrimaryPublicIP
+		flatten["secondary_public_ip"] = setts.SecondaryPublicIP
 		flattens = append(flattens, flatten)
 	}
 	return flattens

--- a/internal/provider/resource_azure_cloud_router_connection.go
+++ b/internal/provider/resource_azure_cloud_router_connection.go
@@ -215,7 +215,7 @@ func resourceAzureExpressRouteConnRead(ctx context.Context, d *schema.ResourceDa
 	_ = d.Set("azure_service_key", resp.CloudSettings.AzureServiceKey)
 	_ = d.Set("po_number", resp.PONumber)
 
-	if resp.CloudSettings.PublicIP != "" {
+	if resp.CloudSettings.PublicIP != "" || resp.CloudSettings.PrimaryPublicIP != "" || resp.CloudSettings.SecondaryPublicIP != "" {
 		_ = d.Set("is_public", true)
 	} else {
 		_ = d.Set("is_public", false)

--- a/internal/provider/resource_azure_cloud_router_connection.go
+++ b/internal/provider/resource_azure_cloud_router_connection.go
@@ -118,6 +118,14 @@ func resourceAzureExpressRouteConn() *schema.Resource {
 				Computed:    true,
 				Description: "The microsoft peering vlan.",
 			},
+			"primary_public_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"secondary_public_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"etl": {
 				Type:        schema.TypeFloat,
 				Computed:    true,
@@ -215,8 +223,10 @@ func resourceAzureExpressRouteConnRead(ctx context.Context, d *schema.ResourceDa
 	_ = d.Set("azure_service_key", resp.CloudSettings.AzureServiceKey)
 	_ = d.Set("po_number", resp.PONumber)
 
-	if resp.CloudSettings.PublicIP != "" || resp.CloudSettings.PrimaryPublicIP != "" || resp.CloudSettings.SecondaryPublicIP != "" {
+	if resp.CloudSettings.PrimaryPublicIP != "" || resp.CloudSettings.SecondaryPublicIP != "" {
 		_ = d.Set("is_public", true)
+		_ = d.Set("primary_public_ip", resp.CloudSettings.PrimaryPublicIP)
+		_ = d.Set("secondary_public_ip", resp.CloudSettings.SecondaryPublicIP)
 	} else {
 		_ = d.Set("is_public", false)
 	}

--- a/internal/provider/resource_azure_cloud_router_connection_test.go
+++ b/internal/provider/resource_azure_cloud_router_connection_test.go
@@ -45,7 +45,7 @@ func TestAccCloudRouterConnectionAzureRequiredFields(t *testing.T) {
 			},
 			{
 				Config: crConnAzureResult.Hcl,
-				Check:  resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "is_public", "true"),
+				Check:  resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "is_public", "false"),
 			},
 			{
 				ResourceName:            crConnAzureResult.ResourceName,
@@ -61,11 +61,10 @@ func TestAccCloudRouterConnectionAzureRequiredFields(t *testing.T) {
 	})
 }
 
-func TestAccCloudRouterConnectionAzureNoPublicIPs(t *testing.T) {
+func TestAccCloudRouterConnectionPublicAzureIsPublic(t *testing.T) {
 	testutil.PreCheck(t, []string{"ARM_SUBSCRIPTION_ID", "ARM_CLIENT_ID", "ARM_CLIENT_SECRET", "ARM_TENANT_ID"})
 
-	crConnAzureResult := testutil.RHclCloudRouterConnectionAzureNoPublicIPs()
-	var cloudRouterCircuitId, cloudRouterConnectionCircuitId string
+	crConnAzureResult := testutil.RHclCloudRouterConnectionAzurePublic()
 
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:         testAccProviders,
@@ -83,7 +82,7 @@ func TestAccCloudRouterConnectionAzureNoPublicIPs(t *testing.T) {
 			},
 			{
 				Config: crConnAzureResult.Hcl,
-				Check:  resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "is_public", "false"),
+				Check:  resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "is_public", "true"),
 			},
 		},
 	})

--- a/internal/provider/resource_azure_cloud_router_connection_test.go
+++ b/internal/provider/resource_azure_cloud_router_connection_test.go
@@ -45,8 +45,8 @@ func TestAccCloudRouterConnectionAzureRequiredFields(t *testing.T) {
 			},
 			{
 				Config: crConnAzureResult.Hcl,
-				Check: resource.TestCheckResourceAttr(crConnAzureResult.ResourceName,"is_public","true"),
-			},		
+				Check:  resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "is_public", "true"),
+			},
 			{
 				ResourceName:            crConnAzureResult.ResourceName,
 				ImportState:             true,
@@ -62,29 +62,29 @@ func TestAccCloudRouterConnectionAzureRequiredFields(t *testing.T) {
 }
 
 func TestAccCloudRouterConnectionAzureNoPublicIPs(t *testing.T) {
-    testutil.PreCheck(t, []string{"ARM_SUBSCRIPTION_ID", "ARM_CLIENT_ID", "ARM_CLIENT_SECRET", "ARM_TENANT_ID"})
+	testutil.PreCheck(t, []string{"ARM_SUBSCRIPTION_ID", "ARM_CLIENT_ID", "ARM_CLIENT_SECRET", "ARM_TENANT_ID"})
 
-    crConnAzureResult := testutil.RHclCloudRouterConnectionAzureNoPublicIPs()
-    var cloudRouterCircuitId, cloudRouterConnectionCircuitId string
+	crConnAzureResult := testutil.RHclCloudRouterConnectionAzureNoPublicIPs()
+	var cloudRouterCircuitId, cloudRouterConnectionCircuitId string
 
-    resource.ParallelTest(t, resource.TestCase{
-        Providers:         testAccProviders,
-        ExternalProviders: testAccExternalProviders,
-        Steps: []resource.TestStep{
-            {
-                Config: crConnAzureResult.Hcl,
-                Check: resource.ComposeTestCheckFunc(
-                    resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "description", crConnAzureResult.Desc),
-                    resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "account_uuid", crConnAzureResult.AccountUuid),
-                    resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "speed", crConnAzureResult.Speed),
-                    resource.TestCheckResourceAttrSet(crConnAzureResult.ResourceName, "circuit_id"),
-                    resource.TestCheckResourceAttrSet(crConnAzureResult.ResourceName, "id"),
-                ),
-            },
-            {
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:         testAccProviders,
+		ExternalProviders: testAccExternalProviders,
+		Steps: []resource.TestStep{
+			{
 				Config: crConnAzureResult.Hcl,
-				Check: resource.TestCheckResourceAttr(crConnAzureResult.ResourceName,"is_public","false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "description", crConnAzureResult.Desc),
+					resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "account_uuid", crConnAzureResult.AccountUuid),
+					resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "speed", crConnAzureResult.Speed),
+					resource.TestCheckResourceAttrSet(crConnAzureResult.ResourceName, "circuit_id"),
+					resource.TestCheckResourceAttrSet(crConnAzureResult.ResourceName, "id"),
+				),
 			},
-        },
-    })
+			{
+				Config: crConnAzureResult.Hcl,
+				Check:  resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "is_public", "false"),
+			},
+		},
+	})
 }

--- a/internal/provider/resource_azure_cloud_router_connection_test.go
+++ b/internal/provider/resource_azure_cloud_router_connection_test.go
@@ -72,16 +72,6 @@ func TestAccCloudRouterConnectionPublicAzureIsPublic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: crConnAzureResult.Hcl,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "description", crConnAzureResult.Desc),
-					resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "account_uuid", crConnAzureResult.AccountUuid),
-					resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "speed", crConnAzureResult.Speed),
-					resource.TestCheckResourceAttrSet(crConnAzureResult.ResourceName, "circuit_id"),
-					resource.TestCheckResourceAttrSet(crConnAzureResult.ResourceName, "id"),
-				),
-			},
-			{
-				Config: crConnAzureResult.Hcl,
 				Check:  resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "is_public", "true"),
 			},
 		},

--- a/internal/provider/resource_azure_cloud_router_connection_test.go
+++ b/internal/provider/resource_azure_cloud_router_connection_test.go
@@ -44,6 +44,10 @@ func TestAccCloudRouterConnectionAzureRequiredFields(t *testing.T) {
 				},
 			},
 			{
+				Config: crConnAzureResult.Hcl,
+				Check: resource.TestCheckResourceAttr(crConnAzureResult.ResourceName,"is_public","true"),
+			},		
+			{
 				ResourceName:            crConnAzureResult.ResourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -55,5 +59,32 @@ func TestAccCloudRouterConnectionAzureRequiredFields(t *testing.T) {
 			},
 		},
 	})
+}
 
+func TestAccCloudRouterConnectionAzureNoPublicIPs(t *testing.T) {
+    testutil.PreCheck(t, []string{"ARM_SUBSCRIPTION_ID", "ARM_CLIENT_ID", "ARM_CLIENT_SECRET", "ARM_TENANT_ID"})
+
+    crConnAzureResult := testutil.RHclCloudRouterConnectionAzureNoPublicIPs()
+    var cloudRouterCircuitId, cloudRouterConnectionCircuitId string
+
+    resource.ParallelTest(t, resource.TestCase{
+        Providers:         testAccProviders,
+        ExternalProviders: testAccExternalProviders,
+        Steps: []resource.TestStep{
+            {
+                Config: crConnAzureResult.Hcl,
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "description", crConnAzureResult.Desc),
+                    resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "account_uuid", crConnAzureResult.AccountUuid),
+                    resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "speed", crConnAzureResult.Speed),
+                    resource.TestCheckResourceAttrSet(crConnAzureResult.ResourceName, "circuit_id"),
+                    resource.TestCheckResourceAttrSet(crConnAzureResult.ResourceName, "id"),
+                ),
+            },
+            {
+				Config: crConnAzureResult.Hcl,
+				Check: resource.TestCheckResourceAttr(crConnAzureResult.ResourceName,"is_public","false"),
+			},
+        },
+    })
 }

--- a/internal/testutil/test_hcls.go
+++ b/internal/testutil/test_hcls.go
@@ -194,6 +194,8 @@ const AzureServiceProviderNameDev = "Packet Fabric Test"
 const AzureExpressRouteTier = "Standard"
 const AzureExpressRouteFamily = "MeteredData"
 const AzurePeeringBandwidth = 100 // must match const CloudRouterConnSpeed and HostedCloudSpeed
+const AzurePrimaryPublicIp = "10.7.1.0/28"
+const AzureSecondaryPublicIp = "10.8.1.0/28"
 
 // packetfabric_cs_aws_dedicated_connection
 // packetfabric_cs_google_dedicated_connection
@@ -1194,7 +1196,57 @@ func RHclCloudRouterConnectionAzure() RHclCloudRouterConnectionAzureResult {
 		hclCloudRouterRes.ResourceName,
 		os.Getenv("PF_ACCOUNT_ID"),
 		uniqueDesc,
-		CloudRouterConnSpeed)
+		CloudRouterConnSpeed,
+		AzurePrimaryPublicIp,
+        AzureSecondaryPublicIp)
+
+	hcl := fmt.Sprintf("%s\n%s", hclCloudRouterRes.Hcl, crcHcl)
+
+	return RHclCloudRouterConnectionAzureResult{
+		HclResultBase: HclResultBase{
+			Hcl:                    hcl,
+			Resource:               pfCloudRouterConnAzure,
+			ResourceName:           resourceName,
+			AdditionalResourceName: hclCloudRouterRes.ResourceName,
+		},
+		Desc:        uniqueDesc,
+		AccountUuid: os.Getenv("PF_ACCOUNT_ID"),
+		Speed:       CloudRouterConnSpeed,
+	}
+}
+
+func RHclCloudRouterConnectionAzureNoPublicIPs() RHclCloudRouterConnectionAzureResult {
+
+	hclCloudRouterRes := RHclCloudRouter(DefaultRHclCloudRouterInput())
+	resourceName, hclName := GenerateUniqueResourceName(pfCloudRouterConnAzure)
+	uniqueDesc := GenerateUniqueName()
+	log.Printf("Resource: %s, Resource name: %s, description: %s\n", pfCloudRouterConnAzure, hclName, uniqueDesc)
+
+	host := os.Getenv("PF_HOST")
+	AzureLocation, AzurePeeringLocation, AzureServiceProviderName := setAzureLocations(host)
+
+	primaryPublicIp := ""
+    secondaryPublicIp := ""
+
+	crcHcl := fmt.Sprintf(
+		RResourceCloudRouterConnectionAzure,
+		AzureLocation,
+		AzureLocation,
+		AzureVnetCidr,
+		AzureSubnetCidr,
+		AzureLocation,
+		AzurePeeringLocation,
+		AzureServiceProviderName,
+		AzurePeeringBandwidth,
+		AzureExpressRouteTier,
+		AzureExpressRouteFamily,
+		hclName,
+		hclCloudRouterRes.ResourceName,
+		os.Getenv("PF_ACCOUNT_ID"),
+		uniqueDesc,
+		CloudRouterConnSpeed,
+		primaryPublicIp,
+        secondaryPublicIp)
 
 	hcl := fmt.Sprintf("%s\n%s", hclCloudRouterRes.Hcl, crcHcl)
 

--- a/internal/testutil/test_hcls.go
+++ b/internal/testutil/test_hcls.go
@@ -194,8 +194,6 @@ const AzureServiceProviderNameDev = "Packet Fabric Test"
 const AzureExpressRouteTier = "Standard"
 const AzureExpressRouteFamily = "MeteredData"
 const AzurePeeringBandwidth = 100 // must match const CloudRouterConnSpeed and HostedCloudSpeed
-const AzurePrimaryPublicIp = "10.7.1.0/28"
-const AzureSecondaryPublicIp = "10.8.1.0/28"
 
 // packetfabric_cs_aws_dedicated_connection
 // packetfabric_cs_google_dedicated_connection
@@ -1197,8 +1195,7 @@ func RHclCloudRouterConnectionAzure() RHclCloudRouterConnectionAzureResult {
 		os.Getenv("PF_ACCOUNT_ID"),
 		uniqueDesc,
 		CloudRouterConnSpeed,
-		AzurePrimaryPublicIp,
-		AzureSecondaryPublicIp)
+		false)
 
 	hcl := fmt.Sprintf("%s\n%s", hclCloudRouterRes.Hcl, crcHcl)
 
@@ -1215,7 +1212,7 @@ func RHclCloudRouterConnectionAzure() RHclCloudRouterConnectionAzureResult {
 	}
 }
 
-func RHclCloudRouterConnectionAzureNoPublicIPs() RHclCloudRouterConnectionAzureResult {
+func RHclCloudRouterConnectionAzurePublic() RHclCloudRouterConnectionAzureResult {
 
 	hclCloudRouterRes := RHclCloudRouter(DefaultRHclCloudRouterInput())
 	resourceName, hclName := GenerateUniqueResourceName(pfCloudRouterConnAzure)
@@ -1224,9 +1221,6 @@ func RHclCloudRouterConnectionAzureNoPublicIPs() RHclCloudRouterConnectionAzureR
 
 	host := os.Getenv("PF_HOST")
 	AzureLocation, AzurePeeringLocation, AzureServiceProviderName := setAzureLocations(host)
-
-	primaryPublicIp := ""
-	secondaryPublicIp := ""
 
 	crcHcl := fmt.Sprintf(
 		RResourceCloudRouterConnectionAzure,
@@ -1245,8 +1239,7 @@ func RHclCloudRouterConnectionAzureNoPublicIPs() RHclCloudRouterConnectionAzureR
 		os.Getenv("PF_ACCOUNT_ID"),
 		uniqueDesc,
 		CloudRouterConnSpeed,
-		primaryPublicIp,
-		secondaryPublicIp)
+		true)
 
 	hcl := fmt.Sprintf("%s\n%s", hclCloudRouterRes.Hcl, crcHcl)
 

--- a/internal/testutil/test_hcls.go
+++ b/internal/testutil/test_hcls.go
@@ -1198,7 +1198,7 @@ func RHclCloudRouterConnectionAzure() RHclCloudRouterConnectionAzureResult {
 		uniqueDesc,
 		CloudRouterConnSpeed,
 		AzurePrimaryPublicIp,
-        AzureSecondaryPublicIp)
+		AzureSecondaryPublicIp)
 
 	hcl := fmt.Sprintf("%s\n%s", hclCloudRouterRes.Hcl, crcHcl)
 
@@ -1226,7 +1226,7 @@ func RHclCloudRouterConnectionAzureNoPublicIPs() RHclCloudRouterConnectionAzureR
 	AzureLocation, AzurePeeringLocation, AzureServiceProviderName := setAzureLocations(host)
 
 	primaryPublicIp := ""
-    secondaryPublicIp := ""
+	secondaryPublicIp := ""
 
 	crcHcl := fmt.Sprintf(
 		RResourceCloudRouterConnectionAzure,
@@ -1246,7 +1246,7 @@ func RHclCloudRouterConnectionAzureNoPublicIPs() RHclCloudRouterConnectionAzureR
 		uniqueDesc,
 		CloudRouterConnSpeed,
 		primaryPublicIp,
-        secondaryPublicIp)
+		secondaryPublicIp)
 
 	hcl := fmt.Sprintf("%s\n%s", hclCloudRouterRes.Hcl, crcHcl)
 

--- a/internal/testutil/test_schemas.go
+++ b/internal/testutil/test_schemas.go
@@ -169,6 +169,10 @@ resource "packetfabric_cloud_router_connection_azure" "%s" {
   description       = "%s"
   speed             = "%s"
   azure_service_key = azurerm_express_route_circuit.azure_express_route1.service_key
+  cloud_settings {
+    primary_public_ip   = "%s"
+    secondary_public_ip = "%s"
+  }
 }`
 
 // Resource: packetfabric_cloud_router_connection_google

--- a/internal/testutil/test_schemas.go
+++ b/internal/testutil/test_schemas.go
@@ -163,16 +163,13 @@ resource "azurerm_express_route_circuit" "azure_express_route1" {
   }
 }
 resource "packetfabric_cloud_router_connection_azure" "%s" {
-  provider          = packetfabric
+  provider          = azure
   circuit_id        = %s.id
   account_uuid      = "%s"
   description       = "%s"
   speed             = "%s"
   azure_service_key = azurerm_express_route_circuit.azure_express_route1.service_key
-  cloud_settings {
-    primary_public_ip   = "%s"
-    secondary_public_ip = "%s"
-  }
+  is_public         = %v
 }`
 
 // Resource: packetfabric_cloud_router_connection_google

--- a/internal/testutil/test_schemas.go
+++ b/internal/testutil/test_schemas.go
@@ -163,7 +163,7 @@ resource "azurerm_express_route_circuit" "azure_express_route1" {
   }
 }
 resource "packetfabric_cloud_router_connection_azure" "%s" {
-  provider          = azure
+  provider          = packetfabric
   circuit_id        = %s.id
   account_uuid      = "%s"
   description       = "%s"


### PR DESCRIPTION
## Description
Azure stores the public ip differently due to the primary/secondary architecture.