### PR TITLE
Azure l3 fix

### DIFF
--- a/internal/provider/resource_azure_cloud_router_connection_test.go
+++ b/internal/provider/resource_azure_cloud_router_connection_test.go
@@ -4,6 +4,8 @@ package provider
 
 import (
 	"fmt"
+	"strings"
+	"regexp"
 	"testing"
 
 	"github.com/PacketFabric/terraform-provider-packetfabric/internal/testutil"
@@ -16,6 +18,9 @@ func TestAccCloudRouterConnectionAzureRequiredFields(t *testing.T) {
 
 	crConnAzureResult := testutil.RHclCloudRouterConnectionAzure()
 	var cloudRouterCircuitId, cloudRouterConnectionCircuitId string
+
+
+	return
 
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:         testAccProviders,
@@ -74,6 +79,48 @@ func TestAccCloudRouterConnectionPublicAzureIsPublic(t *testing.T) {
 			{
 				Config: crConnAzureResult.Hcl,
 				Check:  resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "is_public", "true"),
+			},
+		},
+	})
+}
+
+func TestAccCloudRouterConnectionAzureBgpL3(t *testing.T) {
+	testutil.PreCheck(t, []string{"ARM_SUBSCRIPTION_ID", "ARM_CLIENT_ID", "ARM_CLIENT_SECRET", "ARM_TENANT_ID"})
+
+	crConnAzureResult := testutil.RHclCloudRouterConnectionAzureBgpL3()
+
+	r := regexp.MustCompile(`disabled *= *false`)
+	matches := r.FindAllString(crConnAzureResult.Hcl, -1)
+	modify := strings.Replace(matches[0], "false", "true", -1)
+	updatedHcl := r.ReplaceAllString(crConnAzureResult.Hcl, modify)
+
+	const rn = "packetfabric_cloud_router_bgp_session.cr_az_tf_bgp_test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:         testAccProviders,
+		ExternalProviders: testAccExternalProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: crConnAzureResult.Hcl,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "description", crConnAzureResult.Desc),
+					resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "account_uuid", crConnAzureResult.AccountUuid),
+					resource.TestCheckResourceAttr(crConnAzureResult.ResourceName, "speed", crConnAzureResult.Speed),
+					resource.TestCheckResourceAttrSet(crConnAzureResult.ResourceName, "circuit_id"),
+					resource.TestCheckResourceAttrSet(crConnAzureResult.ResourceName, "subscription_term"),
+					resource.TestCheckResourceAttrSet(crConnAzureResult.ResourceName, "id"),
+				),
+			},
+			{
+				Config: updatedHcl,
+				Check: func(s *terraform.State) error {
+					rs, ok := s.RootModule().Resources[rn]
+					if !ok {
+						return fmt.Errorf("Not found: %s", rn)
+					}
+					fmt.Println("TODO: verify:",  rs.Primary.Attributes)
+					return nil
+				},
 			},
 		},
 	})

--- a/internal/provider/resource_azure_cloud_router_connection_test.go
+++ b/internal/provider/resource_azure_cloud_router_connection_test.go
@@ -19,9 +19,6 @@ func TestAccCloudRouterConnectionAzureRequiredFields(t *testing.T) {
 	crConnAzureResult := testutil.RHclCloudRouterConnectionAzure()
 	var cloudRouterCircuitId, cloudRouterConnectionCircuitId string
 
-
-	return
-
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:         testAccProviders,
 		ExternalProviders: testAccExternalProviders,

--- a/internal/provider/resource_bgp_session.go
+++ b/internal/provider/resource_bgp_session.go
@@ -481,17 +481,14 @@ func extractBgpSessionUpdate(d *schema.ResourceData, c *packetfabric.PFClient, c
 	// Azure BGP session Update: l3_address = Azure Subnet (primary or secondary)
 	// set l3Address based on the values of primarySubnet and secondarySubnet when modified
 	// This is a temporary solution until the BGP API is refactored.
-	var primary, secondary string
-	if primarySubnet, ok := d.GetOk("primary_subnet"); ok {
-		primary = primarySubnet.(string)
-		if d.HasChange("primary_subnet") {
-			bgpSession.L3Address = primary
+	if d.HasChange("primary_subnet") {
+		if primarySubnet, ok := d.GetOk("primary_subnet"); ok {
+			bgpSession.L3Address = primarySubnet.(string)
 		}
 	}
-	if secondarySubnet, ok := d.GetOk("secondary_subnet"); ok {
-		secondary = secondarySubnet.(string)
-		if d.HasChange("secondary_subnet") {
-			bgpSession.L3Address = secondary
+	if d.HasChange("secondary_subnet") {
+		if secondarySubnet, ok := d.GetOk("secondary_subnet"); ok {
+			bgpSession.L3Address = secondarySubnet.(string)
 		}
 	}
 	// For Azure, if the L3Address is still not set, retrieve the Subnet field

--- a/internal/provider/resource_bgp_session.go
+++ b/internal/provider/resource_bgp_session.go
@@ -546,12 +546,12 @@ func extractL3Address(bgpSession *packetfabric.BgpSession, c *packetfabric.PFCli
 	}
 	connectionType := crConnection.CloudSettings.AzureConnectionType
 	switch connectionType {
-		case "primary":
-			value = bgpSession.PrimarySubnet
-		case "secondary":
-			value = bgpSession.SecondarySubnet
-		default:
-			err = fmt.Errorf("Invalid value for subnet: \"%s\"", connectionType)
+	case "primary":
+		value = bgpSession.PrimarySubnet
+	case "secondary":
+		value = bgpSession.SecondarySubnet
+	default:
+		err = fmt.Errorf("Invalid value for subnet: \"%s\"", connectionType)
 	}
 	if "" == value && nil == err {
 		noValueMessageFormat := "The l3_address should use \"%s\" subnet but it has no value"

--- a/internal/testutil/test_hcls.go
+++ b/internal/testutil/test_hcls.go
@@ -1292,6 +1292,51 @@ func RHclCloudRouterConnectionAzurePublic() RHclCloudRouterConnectionAzureResult
 	}
 }
 
+func RHclCloudRouterConnectionAzureBgpL3() RHclCloudRouterConnectionAzureResult {
+	hclCloudRouterRes := RHclCloudRouter(DefaultRHclCloudRouterInput())
+	resourceName, hclName := GenerateUniqueResourceName(pfCloudRouterConnAzure)
+	uniqueDesc := GenerateUniqueName()
+	log.Printf("Resource: %s, Resource name: %s, description: %s\n", pfCloudRouterConnAzure, hclName, uniqueDesc)
+
+	host := os.Getenv("PF_HOST")
+	testName := "t3"
+	AzureLocation, AzurePeeringLocation, AzureServiceProviderName := setAzureLocations(host)
+
+	crcHcl := fmt.Sprintf(
+		RResourceCloudRouterConnectionAzureBgp,
+		testName,
+		AzureLocation,
+		uniqueDesc,
+		AzureLocationDev,
+		AzurePeeringLocation,
+		AzureServiceProviderName,
+		AzurePeeringBandwidth,
+		AzureExpressRouteTier,
+		AzureExpressRouteFamily,
+		hclName,
+		os.Getenv("PF_ACCOUNT_ID"),
+		uniqueDesc,
+		hclCloudRouterRes.ResourceName,
+		AzurePeeringBandwidth,
+		hclCloudRouterRes.ResourceName,
+		resourceName,
+		AzureSubnetCidr)
+
+	hcl := fmt.Sprintf("%s\n%s", hclCloudRouterRes.Hcl, crcHcl)
+
+	return RHclCloudRouterConnectionAzureResult{
+		HclResultBase: HclResultBase{
+			Hcl:                    hcl,
+			Resource:               pfCloudRouterConnAzure,
+			ResourceName:           resourceName,
+			AdditionalResourceName: hclCloudRouterRes.ResourceName,
+		},
+		Desc:        uniqueDesc,
+		AccountUuid: os.Getenv("PF_ACCOUNT_ID"),
+		Speed:       CloudRouterConnSpeed,
+	}
+}
+
 // packetfabric_cloud_router_connection_ibm
 func RHclCloudRouterConnectionIbm() RHclCloudRouterConnectionIbmResult {
 

--- a/internal/testutil/test_schemas.go
+++ b/internal/testutil/test_schemas.go
@@ -125,6 +125,64 @@ const RResourceCloudProviderCredentialGoogle = `resource "packetfabric_cloud_pro
 }`
 
 // Resource: packetfabric_cloud_router_connection_azure
+const RResourceCloudRouterConnectionAzureBgp = `provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+resource "azurerm_resource_group" "resource_group1" {
+  name     = "terraform-test-acc-azure-rg1-%s"
+  location = "%s"
+}
+resource "azurerm_express_route_circuit" "azure_express_route1" {
+  name                  = "%s"
+  resource_group_name   = azurerm_resource_group.resource_group1.name
+  location              = "%s"
+  peering_location      = "%s"
+  service_provider_name = "%s"
+  bandwidth_in_mbps     = %d
+  sku {
+    tier   = "%s"
+    family = "%s"
+  }
+  tags = {
+    environment = "terraform-test-acc-azure1"
+  }
+}
+//resource "packetfabric_cloud_router_connection_azure" "cr1-azr-er-circuit-1" 
+resource "packetfabric_cloud_router_connection_azure" "%s" {
+  provider          = packetfabric
+  account_uuid      = "%s"
+  description       = "%s"
+  circuit_id        = %s.id
+  azure_service_key = azurerm_express_route_circuit.azure_express_route1.service_key
+  speed             = "%dMbps"
+  maybe_nat         = false
+  is_public         = false
+  labels            = ["dev", "tf-azure-bgp-test"]
+}
+resource "packetfabric_cloud_router_bgp_session" "cr_az_tf_bgp_test" {
+  provider      = packetfabric
+  circuit_id    = %s.id
+  connection_id = %s.id
+  disabled      = false
+  remote_asn    = 64513
+  prefixes {
+    prefix     = "0.0.0.0/0"
+    type       = "out"
+    match_type = "orlonger"
+  }
+  prefixes {
+    prefix     = "0.0.0.0/0"
+    type       = "in"
+    match_type = "orlonger"
+  }
+  primary_subnet = "%s"
+}`
+
+// Resource: packetfabric_cloud_router_connection_azure
 const RResourceCloudRouterConnectionAzure = `provider "azurerm" {
   features {
     resource_group {


### PR DESCRIPTION
## Description

When updating a BGP session for Azure, the l3_address was not being set unless on of the subnets was changed.

This fix checks for this situation and pulls the current BGP session information and tries to use the value for "subnet" if found or if not, produces an error since this should not happen.