### PR TITLE
change pool_prefixes and pre_nat_sources to be set rather than a list…

### DIFF
--- a/docs/resources/packetfabric_cloud_router_bgp_session.md
+++ b/docs/resources/packetfabric_cloud_router_bgp_session.md
@@ -198,10 +198,10 @@ Optional:
 - `dnat_mappings` (Block Set) Translate the destination IP address. (see [below for nested schema](#nestedblock--nat--dnat_mappings))
 - `nat_type` (String) The NAT type of the NAT connection, source NAT (overload) or destination NAT (inline_dnat). 
 		Enum: overload, inline_dnat. Defaults: overload
-- `pool_prefixes` (List of String) If using NAT overload, all prefixes that are NATed on this connection will be translated to the pool prefix address.
+- `pool_prefixes` (Set of String) If using NAT overload, all prefixes that are NATed on this connection will be translated to the pool prefix address.
 
 	Example: 10.0.0.0/32
-- `pre_nat_sources` (List of String) If using NAT overload, this is the prefixes from the cloud that you want to associate with the NAT pool.
+- `pre_nat_sources` (Set of String) If using NAT overload, this is the prefixes from the cloud that you want to associate with the NAT pool.
 
 	Example: 10.0.0.0/24
 

--- a/internal/provider/resource_bgp_session.go
+++ b/internal/provider/resource_bgp_session.go
@@ -144,7 +144,7 @@ func resourceBgpSession() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"pre_nat_sources": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Optional:    true,
 							Description: "If using NAT overload, this is the prefixes from the cloud that you want to associate with the NAT pool.\n\n\tExample: 10.0.0.0/24",
 							Elem: &schema.Schema{
@@ -153,7 +153,7 @@ func resourceBgpSession() *schema.Resource {
 							},
 						},
 						"pool_prefixes": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Optional:    true,
 							Description: "If using NAT overload, all prefixes that are NATed on this connection will be translated to the pool prefix address.\n\n\tExample: 10.0.0.0/32",
 							Elem: &schema.Schema{
@@ -578,6 +578,10 @@ func extractConnBgpSessionPrefixes(d *schema.ResourceData) []packetfabric.BgpPre
 	return make([]packetfabric.BgpPrefix, 0)
 }
 
+func setToList(set interface{}) []interface{} {
+	return set.(*schema.Set).List()
+}
+
 func extractConnBgpSessionNat(n map[string]interface{}) *packetfabric.BgpNat {
 	nat := packetfabric.BgpNat{}
 	if direction := n["direction"]; direction != nil {
@@ -586,8 +590,8 @@ func extractConnBgpSessionNat(n map[string]interface{}) *packetfabric.BgpNat {
 	if natType := n["nat_type"]; natType != nil {
 		nat.NatType = natType.(string)
 	}
-	nat.PreNatSources = extractPreNatSources(n["pre_nat_sources"])
-	nat.PoolPrefixes = extractPoolPrefixes(n["pool_prefixes"])
+	nat.PreNatSources = extractPreNatSources(setToList(n["pre_nat_sources"]))
+	nat.PoolPrefixes = extractPoolPrefixes(setToList(n["pool_prefixes"]))
 	nat.DnatMappings = extractConnBgpSessionDnat(n["dnat_mappings"].(*schema.Set))
 	return &nat
 }


### PR DESCRIPTION
… to avoid ordering differences as an update

## Description

This change prevents insignificant changes in prefix order being seen as an update.

Closes #546